### PR TITLE
Allow date-time strings without milliseconds. Fixes #23

### DIFF
--- a/fastjsonschema/draft04.py
+++ b/fastjsonschema/draft04.py
@@ -18,7 +18,7 @@ JSON_TYPE_TO_PYTHON_TYPE = {
 class CodeGeneratorDraft04(CodeGenerator):
     # pylint: disable=line-too-long
     FORMAT_REGEXS = {
-        'date-time': r'^\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d\.\d+(?:[+-][0-2]\d:[0-5]\d|Z)?$',
+        'date-time': r'^\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d(?:\.\d+)?(?:[+-][0-2]\d:[0-5]\d|Z)?$',
         'email': r'^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$',
         'hostname': (
             r'^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*'

--- a/tests/test_datetime.py
+++ b/tests/test_datetime.py
@@ -1,0 +1,15 @@
+
+import pytest
+
+from fastjsonschema import JsonSchemaException
+
+
+exc = JsonSchemaException('data must be date-time')
+@pytest.mark.parametrize('value, expected', [
+    ('', exc),
+    ('bla', exc),
+    ('2018-02-05T14:17:10.00Z', '2018-02-05T14:17:10.00Z'),
+    ('2018-02-05T14:17:10Z', '2018-02-05T14:17:10Z'),
+])
+def test_datetime(asserter, value, expected):
+    asserter({'type': 'string', 'format': 'date-time'}, value, expected)


### PR DESCRIPTION
Added a test case that fails with the old regex and is green with the new regex.