### PR TITLE
Allow non string keys

### DIFF
--- a/fastjsonschema/draft04.py
+++ b/fastjsonschema/draft04.py
@@ -424,7 +424,7 @@ class CodeGeneratorDraft04(CodeGenerator):
         with self.l('if {variable}_is_dict:'):
             self.create_variable_keys()
             for key, prop_definition in self._definition['properties'].items():
-                key_name = re.sub(r'($[^a-zA-Z]|[^a-zA-Z0-9])', '', key)
+                key_name = re.sub(r'($[^a-zA-Z]|[^a-zA-Z0-9])', '', key) if type(key) == str else key
                 with self.l('if "{}" in {variable}_keys:', key):
                     self.l('{variable}_keys.remove("{}")', key)
                     self.l('{variable}_{0} = {variable}["{1}"]', key_name, key)


### PR DESCRIPTION
The json standard allows integers to be keys for schema dictionaries:

```
{
    "type": "object",
    "properties": {
        "bet_limits": {
            "type": "object",
            "properties": {
                2: {"type": "number", "example": 500},
                3: {"type": "number", "example": 250},
                4: {"type": "number", "example": 100},
                5: {"type": "number", "example": 100},
            },
        },
    },
    "additionalProperties": False,
}
```