### PR TITLE
Python 3.7 regex bug fixed

### DIFF
--- a/fastjsonschema/__init__.py
+++ b/fastjsonschema/__init__.py
@@ -4,7 +4,7 @@
 #  \/   \/           If you look at it, you might die.
 #
 
-"""
+r"""
 Installation
 ************
 

--- a/fastjsonschema/draft04.py
+++ b/fastjsonschema/draft04.py
@@ -221,7 +221,7 @@ class CodeGeneratorDraft04(CodeGenerator):
         with self.l('if isinstance({variable}, str):'):
             pattern = self._definition['pattern']
             safe_pattern = pattern.replace('"', '\\"')
-            end_of_string_fixed_pattern = DOLLAR_FINDER.sub(r'\Z', pattern)
+            end_of_string_fixed_pattern = DOLLAR_FINDER.sub(r'\\Z', pattern)
             self._compile_regexps[pattern] = re.compile(end_of_string_fixed_pattern)
             with self.l('if not REGEX_PATTERNS["{}"].search({variable}):', safe_pattern):
                 self.l('raise JsonSchemaException("{name} must match pattern {}")', safe_pattern)

--- a/pylintrc
+++ b/pylintrc
@@ -3,8 +3,8 @@
 ignore=tests
 
 [MESSAGES CONTROL]
-# missing-docstring only for now, remove after this issue is deployed https://github.com/PyCQA/pylint/issues/1164
-disable=missing-docstring
+# missing-docstring can be removed after this issue is deployed https://github.com/PyCQA/pylint/issues/1164
+disable=duplicate-code,missing-docstring
 
 [REPORTS]
 output-format=colorized

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py{34,35,36}
+envlist = py{34,35,36,37}
 
 [testenv]
 whitelist_externals =

--- a/tox.ini
+++ b/tox.ini
@@ -4,10 +4,16 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py{34,35,36,37}
+envlist = py{34,35,36,37},lint
 
 [testenv]
-whitelist_externals =
+deps =
     pytest
 commands =
-    pytest
+    pytest -m "not benchmark"
+
+[testenv:lint]
+deps =
+    pylint
+commands =
+    pylint fastjsonschema


### PR DESCRIPTION
Added py37 to tox environment list.

It finds an error with my previous PR:

The docs show a change in `Pattern.sub`.
```
Changed in version 3.7: Unknown escapes in repl consisting of '\' and an ASCII letter now are errors.
```

```
>>> import re
>>> DOLLAR_FINDER = re.compile(r"(?<!\\)\$")
>>> DOLLAR_FINDER.sub(r'\Z', 'hello$')
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/sre_parse.py", line 1021, in parse_template
    this = chr(ESCAPES[this][1])
KeyError: '\\Z'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.7/re.py", line 309, in _subx
    template = _compile_repl(template, pattern)
  File "/usr/local/lib/python3.7/re.py", line 300, in _compile_repl
    return sre_parse.parse_template(repl, pattern)
  File "/usr/local/lib/python3.7/sre_parse.py", line 1024, in parse_template
    raise s.error('bad escape %s' % this, len(this))
re.error: bad escape \Z at position 0
>>> DOLLAR_FINDER.sub(r'\\Z', 'hello$')
'hello\\Z'
```