### PR TITLE
Fix escaping for “pattern” and “patternProperties”

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,13 +30,14 @@ jsonschemasuitcases:
 	git submodule update
 
 test: venv jsonschemasuitcases
-	${PYTHON} -m pytest --benchmark-skip
+	${PYTHON} -m pytest -W default --benchmark-skip
 test-lf: venv jsonschemasuitcases
-	${PYTHON} -m pytest --benchmark-skip --last-failed
+	${PYTHON} -m pytest -W default --benchmark-skip --last-failed
 
 # Call make benchmark-save before change and then make benchmark to compare results.
 benchmark: venv jsonschemasuitcases
 	${PYTHON} -m pytest \
+		-W default \
 		--benchmark-only \
 		--benchmark-sort=name \
 		--benchmark-group-by=fullfunc \
@@ -45,6 +46,7 @@ benchmark: venv jsonschemasuitcases
 		--benchmark-compare-fail='min:5%'
 benchmark-save: venv jsonschemasuitcases
 	${PYTHON} -m pytest \
+		-W default \
 		--benchmark-only \
 		--benchmark-sort=name \
 		--benchmark-group-by=fullfunc \

--- a/fastjsonschema/draft04.py
+++ b/fastjsonschema/draft04.py
@@ -222,7 +222,7 @@ class CodeGeneratorDraft04(CodeGenerator):
     def generate_pattern(self):
         with self.l('if isinstance({variable}, str):'):
             pattern = self._definition['pattern']
-            safe_pattern = pattern.replace('"', '\\"')
+            safe_pattern = pattern.replace('\\', '\\\\').replace('"', '\\"')
             end_of_string_fixed_pattern = DOLLAR_FINDER.sub(r'\\Z', pattern)
             self._compile_regexps[pattern] = re.compile(end_of_string_fixed_pattern)
             with self.l('if not REGEX_PATTERNS[{}].search({variable}):', repr(pattern)):

--- a/fastjsonschema/draft04.py
+++ b/fastjsonschema/draft04.py
@@ -464,7 +464,7 @@ class CodeGeneratorDraft04(CodeGenerator):
                 self._compile_regexps[pattern] = re.compile(pattern)
             with self.l('for {variable}_key, {variable}_val in {variable}.items():'):
                 for pattern, definition in self._definition['patternProperties'].items():
-                    with self.l('if REGEX_PATTERNS["{}"].search({variable}_key):', pattern):
+                    with self.l('if REGEX_PATTERNS[{}].search({variable}_key):', repr(pattern)):
                         with self.l('if {variable}_key in {variable}_keys:'):
                             self.l('{variable}_keys.remove({variable}_key)')
                         self.generate_func_code_block(

--- a/tests/test_pattern_properties.py
+++ b/tests/test_pattern_properties.py
@@ -1,3 +1,6 @@
+import pytest
+
+
 def test_dont_override_variable_names(asserter):
     value = {
         'foo:bar': {
@@ -37,3 +40,31 @@ def test_clear_variables(asserter):
             'bar': {'type': 'object', 'required': ['baz']}
         }
     }, value, value)
+
+
+def test_pattern_with_escape(asserter):
+    value = {
+        '\\n': {}
+    }
+    asserter({
+        'type': 'object',
+        'patternProperties': {
+            '\\\\n': {'type': 'object'}
+        }
+    }, value, value)
+
+
+def test_pattern_with_escape_no_warnings(asserter):
+    value = {
+        'bar': {}
+    }
+
+    with pytest.warns(None) as record:
+        asserter({
+            'type': 'object',
+            'patternProperties': {
+                '\\w+': {'type': 'object'}
+            }
+        }, value, value)
+
+    assert len(record) == 0

--- a/tests/test_string.py
+++ b/tests/test_string.py
@@ -74,6 +74,16 @@ def test_pattern_with_space(asserter, pattern):
     }, ' ', ' ')
 
 
+def test_pattern_with_escape_no_warnings(asserter):
+    with pytest.warns(None) as record:
+        asserter({
+            'type': 'string',
+            'pattern': '\\s'
+        }, ' ', ' ')
+
+    assert len(record) == 0
+
+
 exc = JsonSchemaException('data must be a valid regex')
 @pytest.mark.parametrize('value, expected', [
     ('[a-z]', '[a-z]'),


### PR DESCRIPTION
This is a fix for #50. It consists of 3 steps:

  1. Make `pytest` run with `-W default` so that warnings that are [hidden by default](https://docs.python.org/3/library/warnings.html#default-warning-filter) (such as `DeprecationWarning`) get visible.
  2. Add escaping in exception message for `pattern`. Here, incorrect escaping didn’t affect matching itself.
  2. Add escaping in generated code for `patternProperties`. Here, incorrect escaping **did affect matching itself.**

I added tests for the fixes. I wasn't very clear about the structure of the test suite, so I added them at places that seemed most appropriate. Let me know if I should move them elsewhere or change them in any way.