### PR TITLE
my 2 cents

### DIFF
--- a/fastjsonschema/__init__.py
+++ b/fastjsonschema/__init__.py
@@ -81,10 +81,11 @@ from .exceptions import JsonSchemaException, JsonSchemaDefinitionException
 from .ref_resolver import RefResolver
 from .version import VERSION
 
-__all__ = ('VERSION', 'JsonSchemaException', 'JsonSchemaDefinitionException', 'validate', 'compile', 'compile_to_code')
+__all__ = ('VERSION', 'JsonSchemaException', 'JsonSchemaDefinitionException',
+           'compile', 'compile_to_code', 'get_code_generator_class', 'validate')
 
 
-def validate(definition, data, handlers={}, formats={}):
+def validate(definition, data, handlers: dict = None, formats: dict = None):
     """
     Validation function for lazy programmers or for use cases, when you need
     to call validation only once, so you do not have to compile it first.
@@ -98,13 +99,13 @@ def validate(definition, data, handlers={}, formats={}):
         validate({'type': 'string'}, 'hello')
         # same as: compile({'type': 'string'})('hello')
 
-    Preffered is to use :any:`compile` function.
+    Preferred is to use :any:`compile` function.
     """
     return compile(definition, handlers, formats)(data)
 
 
-# pylint: disable=redefined-builtin,dangerous-default-value,exec-used
-def compile(definition, handlers={}, formats={}):
+# pylint: disable=redefined-builtin,exec-used
+def compile(definition, handlers=None, formats=None):
     """
     Generates validation function for validating JSON schema passed in ``definition``.
     Example:
@@ -144,17 +145,6 @@ def compile(definition, handlers={}, formats={}):
     You can pass mapping from URI to function that should be used to retrieve
     remote schemes used in your ``definition`` in parameter ``handlers``.
 
-    Also, you can pass mapping for custom formats. Key is the name of your
-    formatter and value can be regular expression which will be compiled or
-    callback returning `bool` (or you can raise your own exception).
-
-    .. code-block:: python
-
-        validate = fastjsonschema.compile(definition, formats={
-            'foo': r'foo|bar',
-            'bar': lambda value: value in ('foo', 'bar'),
-        })
-
     Exception :any:`JsonSchemaDefinitionException` is raised when generating the
     code fails (bad definition).
 
@@ -168,8 +158,7 @@ def compile(definition, handlers={}, formats={}):
     return global_state[resolver.get_scope_name()]
 
 
-# pylint: disable=dangerous-default-value
-def compile_to_code(definition, handlers={}, formats={}):
+def compile_to_code(definition, handlers=None, formats=None):
     """
     Generates validation code for validating JSON schema passed in ``definition``.
     Example:
@@ -200,13 +189,13 @@ def compile_to_code(definition, handlers={}, formats={}):
     )
 
 
-def _factory(definition, handlers, formats={}):
-    resolver = RefResolver.from_schema(definition, handlers=handlers)
-    code_generator = _get_code_generator_class(definition)(definition, resolver=resolver, formats=formats)
+def _factory(definition, handlers=None, formats=None):
+    resolver = RefResolver.from_schema(definition, handlers=handlers or {})
+    code_generator = get_code_generator_class(definition)(definition, resolver=resolver, formats=formats or {})
     return resolver, code_generator
 
 
-def _get_code_generator_class(schema):
+def get_code_generator_class(schema):
     # Schema in from draft-06 can be just the boolean value.
     if isinstance(schema, dict):
         schema_version = schema.get('$schema', '')
@@ -215,3 +204,8 @@ def _get_code_generator_class(schema):
         if 'draft-06' in schema_version:
             return CodeGeneratorDraft06
     return CodeGeneratorDraft07
+
+
+# backwards compatibality
+# pylint: disable=invalid-name
+_get_code_generator_class = get_code_generator_class

--- a/fastjsonschema/draft06.py
+++ b/fastjsonschema/draft06.py
@@ -1,6 +1,5 @@
-from .draft04 import CodeGeneratorDraft04, JSON_TYPE_TO_PYTHON_TYPE
+from .draft04 import CodeGeneratorDraft04
 from .exceptions import JsonSchemaDefinitionException
-from .generator import enforce_list
 
 
 class CodeGeneratorDraft06(CodeGeneratorDraft04):
@@ -15,8 +14,8 @@ class CodeGeneratorDraft06(CodeGeneratorDraft04):
         ),
     })
 
-    def __init__(self, definition, resolver=None, formats={}):
-        super().__init__(definition, resolver, formats)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self._json_keywords_to_function.update((
             ('exclusiveMinimum', self.generate_exclusive_minimum),
             ('exclusiveMaximum', self.generate_exclusive_maximum),
@@ -40,9 +39,9 @@ class CodeGeneratorDraft06(CodeGeneratorDraft04):
         True means everything is valid, False everything is invalid.
         """
         if self._definition is False:
-            self.l('raise JsonSchemaException("{name} must not be there")')
+            self.throw('{name} must not be there')
 
-    def generate_type(self):
+    def _get_type_extra_test(self, types):
         """
         Validation of type. Can be one type or list of types.
 
@@ -53,14 +52,7 @@ class CodeGeneratorDraft06(CodeGeneratorDraft04):
             {'type': 'string'}
             {'type': ['string', 'number']}
         """
-        types = enforce_list(self._definition['type'])
-        try:
-            python_types = ', '.join(JSON_TYPE_TO_PYTHON_TYPE[t] for t in types)
-        except KeyError as exc:
-            raise JsonSchemaDefinitionException('Unknown type: {}'.format(exc))
-
         extra = ''
-
         if 'integer' in types:
             extra += ' and not (isinstance({variable}, float) and {variable}.is_integer())'.format(
                 variable=self._variable,
@@ -68,23 +60,21 @@ class CodeGeneratorDraft06(CodeGeneratorDraft04):
 
         if ('number' in types or 'integer' in types) and 'boolean' not in types:
             extra += ' or isinstance({variable}, bool)'.format(variable=self._variable)
-
-        with self.l('if not isinstance({variable}, ({})){}:', python_types, extra):
-            self.l('raise JsonSchemaException("{name} must be {}")', ' or '.join(types))
+        return extra
 
     def generate_exclusive_minimum(self):
         with self.l('if isinstance({variable}, (int, float)):'):
             if not isinstance(self._definition['exclusiveMinimum'], (int, float)):
                 raise JsonSchemaDefinitionException('exclusiveMinimum must be an integer or a float')
             with self.l('if {variable} <= {exclusiveMinimum}:'):
-                self.l('raise JsonSchemaException("{name} must be bigger than {exclusiveMinimum}")')
+                self.throw('{name} must be bigger than {exclusiveMinimum}')
 
     def generate_exclusive_maximum(self):
         with self.l('if isinstance({variable}, (int, float)):'):
             if not isinstance(self._definition['exclusiveMaximum'], (int, float)):
                 raise JsonSchemaDefinitionException('exclusiveMaximum must be an integer or a float')
             with self.l('if {variable} >= {exclusiveMaximum}:'):
-                self.l('raise JsonSchemaException("{name} must be smaller than {exclusiveMaximum}")')
+                self.throw('{name} must be smaller than {exclusiveMaximum}')
 
     def generate_property_names(self):
         """
@@ -106,7 +96,7 @@ class CodeGeneratorDraft06(CodeGeneratorDraft04):
         elif property_names_definition is False:
             self.create_variable_keys()
             with self.l('if {variable}_keys:'):
-                self.l('raise JsonSchemaException("{name} must not be there")')
+                self.throw('{name} must not be there')
         else:
             self.create_variable_is_dict()
             with self.l('if {variable}_is_dict:'):
@@ -124,7 +114,7 @@ class CodeGeneratorDraft06(CodeGeneratorDraft04):
                         with self.l('except JsonSchemaException:'):
                             self.l('{variable}_property_names = False')
                     with self.l('if not {variable}_property_names:'):
-                        self.l('raise JsonSchemaException("{name} must be named by propertyName definition")')
+                        self.throw('{name} must be named by propertyName definition')
 
     def generate_contains(self):
         """
@@ -145,26 +135,27 @@ class CodeGeneratorDraft06(CodeGeneratorDraft04):
             contains_definition = self._definition['contains']
 
             if contains_definition is False:
-                self.l('raise JsonSchemaException("{name} is always invalid")')
+                self.throw('{name} is always invalid')
             elif contains_definition is True:
                 with self.l('if not {variable}:'):
-                    self.l('raise JsonSchemaException("{name} must not be empty")')
+                    self.throw('{name} must not be empty')
             else:
                 self.l('{variable}_contains = False')
-                with self.l('for {variable}_key in {variable}:'):
-                    with self.l('try:'):
-                        self.generate_func_code_block(
-                            contains_definition,
-                            '{}_key'.format(self._variable),
-                            self._variable_name,
-                            clear_variables=True,
-                        )
-                        self.l('{variable}_contains = True')
-                        self.l('break')
-                    self.l('except JsonSchemaException: pass')
+                with self.probing():
+                    with self.l('for {variable}_key in {variable}:'):
+                        with self.l('try:'):
+                            self.generate_func_code_block(
+                                contains_definition,
+                                '{}_key'.format(self._variable),
+                                self._variable_name,
+                                clear_variables=True,
+                            )
+                            self.l('{variable}_contains = True')
+                            self.l('break')
+                        self.l('except JsonSchemaException: pass')
 
                 with self.l('if not {variable}_contains:'):
-                    self.l('raise JsonSchemaException("{name} must contain one of contains definition")')
+                    self.throw('{name} must contain one of contains definition')
 
     def generate_const(self):
         """
@@ -182,4 +173,4 @@ class CodeGeneratorDraft06(CodeGeneratorDraft04):
         if isinstance(const, str):
             const = '"{}"'.format(const)
         with self.l('if {variable} != {}:', const):
-            self.l('raise JsonSchemaException("{name} must be same as const definition")')
+            self.throw('{name} must be same as const definition')

--- a/fastjsonschema/draft07.py
+++ b/fastjsonschema/draft07.py
@@ -7,9 +7,9 @@ class CodeGeneratorDraft07(CodeGeneratorDraft06):
         'iri': r'^\w+:(\/?\/?)[^\s]+\Z',
         'iri-reference': r'^(\w+:(\/?\/?))?[^#\\\s]*(#[^\\\s]*)?\Z',
         'idn-email': r'^[^@]+@[^@]+\.[^@]+\Z',
-        #'idn-hostname': r'',
+        # 'idn-hostname': r'',
         'relative-json-pointer': r'^(?:0|[1-9][0-9]*)(?:#|(?:\/(?:[^~/]|~0|~1)*)*)\Z',
-        #'regex': r'',
+        # 'regex': r'',
         'time': (
             r'^(?P<hour>\d{1,2}):(?P<minute>\d{1,2})'
             r'(?::(?P<second>\d{1,2})(?:\.(?P<microsecond>\d{1,6}))?'
@@ -17,8 +17,8 @@ class CodeGeneratorDraft07(CodeGeneratorDraft06):
         ),
     })
 
-    def __init__(self, definition, resolver=None, formats={}):
-        super().__init__(definition, resolver, formats)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         # pylint: disable=duplicate-code
         self._json_keywords_to_function.update((
             ('if', self.generate_if_then_else),
@@ -88,9 +88,9 @@ class CodeGeneratorDraft07(CodeGeneratorDraft06):
                     self.l('import base64')
                     self.l('{variable} = base64.b64decode({variable})')
                 with self.l('except Exception:'):
-                    self.l('raise JsonSchemaException("{name} must be encoded by base64")')
+                    self.throw('{name} must be encoded by base64')
                 with self.l('if {variable} == "":'):
-                    self.l('raise JsonSchemaException("contentEncoding must be base64")')
+                    self.throw('contentEncoding must be base64')
 
     def generate_content_media_type(self):
         """
@@ -107,10 +107,10 @@ class CodeGeneratorDraft07(CodeGeneratorDraft06):
                 with self.l('try:'):
                     self.l('{variable} = {variable}.decode("utf-8")')
                 with self.l('except Exception:'):
-                    self.l('raise JsonSchemaException("{name} must encoded by utf8")')
+                    self.throw('{name} must encoded by utf8')
             with self.l('if isinstance({variable}, str):'):
                 with self.l('try:'):
                     self.l('import json')
                     self.l('{variable} = json.loads({variable})')
                 with self.l('except Exception:'):
-                    self.l('raise JsonSchemaException("{name} must be valid JSON")')
+                    self.throw('{name} must be valid JSON')

--- a/fastjsonschema/generator.py
+++ b/fastjsonschema/generator.py
@@ -1,9 +1,12 @@
-from collections import OrderedDict
+from collections import defaultdict, deque, OrderedDict
+from contextlib import contextmanager
 import re
 
 from .exceptions import JsonSchemaException
 from .indent import indent
 from .ref_resolver import RefResolver
+
+MARKER = object()
 
 
 def enforce_list(variable):
@@ -12,7 +15,22 @@ def enforce_list(variable):
     return [variable]
 
 
-# pylint: disable=too-many-instance-attributes,too-many-public-methods
+def single_type_optimization(checked_type):
+    def outer(func):
+        def inner(self, *args, **kwargs):
+            if self.has_type(checked_type):
+                self.l('# type of {variable} is {} (enforced by exception)', checked_type)
+                return func(self, *args, **kwargs)
+            variable_suffix = '_is_{}'.format(checked_type)
+            variable_generator = getattr(self, 'create_variable{}'.format(variable_suffix))
+            duplicate = variable_generator()
+            with self.l('if {{variable}}{}:'.format(variable_suffix), deduplicate=duplicate):
+                return func(self, *args, **kwargs)
+        return inner
+    return outer
+
+
+# pylint: disable=too-many-instance-attributes,too-many-public-methods,too-many-arguments
 class CodeGenerator:
     """
     This class is not supposed to be used directly. Anything
@@ -28,17 +46,20 @@ class CodeGenerator:
 
     INDENT = 4  # spaces
 
-    def __init__(self, definition, resolver=None):
+    def __init__(self, definition, resolver=None, formats=None, verbose=False, root_name='data'):
         self._code = []
         self._compile_regexps = {}
-
+        self._custom_formats = formats or {}
+        self._verbose = verbose
+        self._root_name = root_name
         self._variables = set()
         self._indent = 0
-        self._indent_last_line = None
         self._variable = None
         self._variable_name = None
         self._root_definition = definition
         self._definition = None
+        self._probing = 0
+        self._context = deque()
 
         # map schema URIs to validation function names for functions
         # that are not yet generated, but need to be generated
@@ -49,7 +70,6 @@ class CodeGenerator:
         if resolver is None:
             resolver = RefResolver.from_schema(definition)
         self._resolver = resolver
-
         # add main function to `self._needed_validation_functions`
         self._needed_validation_functions[self._resolver.get_uri()] = self._resolver.get_scope_name()
 
@@ -61,8 +81,9 @@ class CodeGenerator:
         Returns generated code of whole validation function as string.
         """
         self._generate_func_code()
-
-        return '\n'.join(self._code)
+        source = [(token, line) for token, line in self._code if token is not MARKER]
+        indented_code = ['{}{}'.format(' ' * self.INDENT * (depth or 0), line or '') for depth, line in source]
+        return '\n'.join(indented_code)
 
     @property
     def global_state(self):
@@ -77,6 +98,7 @@ class CodeGenerator:
             REGEX_PATTERNS=self._compile_regexps,
             re=re,
             JsonSchemaException=JsonSchemaException,
+            custom_formats=self._custom_formats,
         )
 
     @property
@@ -109,7 +131,6 @@ class CodeGenerator:
             ]
         )
 
-
     def _generate_func_code(self):
         if not self._code:
             self.generate_func_code()
@@ -135,8 +156,10 @@ class CodeGenerator:
         self._validation_functions_done.add(uri)
         self.l('')
         with self._resolver.resolving(uri) as definition:
-            with self.l('def {}(data):', name):
-                self.generate_func_code_block(definition, 'data', 'data', clear_variables=True)
+            self.code_break()
+            with self.l('def {{}}(data, scope="{}"):'.format(self._root_name), name):
+                var_name = '{scope}' if self._verbose else 'data'
+                self.generate_func_code_block(definition, 'data', var_name, clear_variables=True)
                 self.l('return data')
 
     def generate_func_code_block(self, definition, variable, variable_name, clear_variables=False):
@@ -165,7 +188,9 @@ class CodeGenerator:
     def run_generate_functions(self, definition):
         for key, func in self._json_keywords_to_function.items():
             if key in definition:
-                func()
+                with self.in_context(key):
+                    self.l('# {}'.format(self.e(key)))
+                    func()
 
     def generate_ref(self):
         """
@@ -187,14 +212,111 @@ class CodeGenerator:
             if uri not in self._validation_functions_done:
                 self._needed_validation_functions[uri] = name
             # call validation function
-            self.l('{}({variable})', name)
+            if self._verbose:
+                self.l('{}({variable}, "{name}")', name)
+            else:
+                self.l('{}({variable})', name)
 
+    def _emit(self, indentation, source_line, deduplicate=False):
+        """
+        Store or ignore the generated line and indentation information.
+
+        If deduplicate is set, try to find an identical line of code at the same indent level and
+        if such exists do not store it - DRY!
+
+        Information is stored as tuple(indentation, source_line).
+        There are two abused values for indentation:
+        - None  which means end of scope of a functional block
+        - marker which marks a special case, e.g. types to instruct the compiler about last checked type of a variable
+
+        :param indentation: level of indentation (it's level and not space-count)
+        :param source_line: python-line source
+        :param deduplicate: check for repetitive code
+        :return:
+        """
+        if deduplicate:
+            for ind, code in reversed(self._code):
+                if ind is None:
+                    break
+                if ind == indentation:
+                    commented = '# {}'.format(source_line)
+                    if code in (source_line, commented):
+                        self._code.append((indentation, commented))
+                        return
+                    break
+        self._code.append((indentation, source_line))
+
+    def code_break(self):
+        self._emit(None, None)
+
+    def mark_type(self, variable, types):
+        for ind, code in reversed(self._code):
+            if ind is None:
+                break
+            if ind is MARKER:
+                code['types'][variable] = types
+                return
+        self._emit(MARKER, defaultdict(types={variable: types}))
+
+    def get_mark(self, mark):
+        for ind, code in reversed(self._code):
+            if ind is None:
+                return None
+            if ind is MARKER:
+                return code[mark]
+        return None
+
+    def has_type(self, atype):
+        types = self.get_mark('types')
+        return types and self._variable in types and atype in types[self._variable]
+
+    @contextmanager
+    def in_context(self, path):
+        """
+        Tracks the context path of the schema definition.
+        :param path: Element to add to the path upon invocation
+        :return:
+        """
+        self._context.append(path)
+        try:
+            yield
+        finally:
+            self._context.pop()
+
+    def context_path(self):
+        path = self._context.copy()
+        return '{} in schema{}'.format(repr(path.pop()), ''.join('[{}]'.format(repr(item)) for item in path))
+
+    @contextmanager
+    def probing(self):
+        """
+        Context manager to keep track of probing blocks to support quick exception generation.
+
+        When using exceptions in constructs like `oneOf` parts of input are probed if they satisfy some definition.
+        One can spot this be `self.l('except JsonSchemaException: pass')` catching exceptions with `pass` statement.
+        In those cases the message held by exception is meaningless so expanding them is useless. That block of code
+        should be executed in the context of:
+
+        ... code-block:: python
+            with self.probing():
+                for definition_item in self._definition['oneOf']:
+                    ..
+        """
+        self._probing += 1
+        try:
+            yield
+        finally:
+            self._probing -= 1
+
+    @property
+    def is_probing(self):
+        return bool(self._probing)
 
     # pylint: disable=invalid-name
     @indent
-    def l(self, line, *args, **kwds):
+    def l(self, line, *args, deduplicate=False, expand_locals=True, **kwds):  # noqa
         """
-        Short-cut of line. Used for inserting line. It's formated with parameters
+        Short-cut of line. Used for inserting line. It's formatted with parameters
         ``variable``, ``variable_name`` (as ``name`` for short-cut), all keys from
         current JSON schema ``definition`` and also passed arguments in ``args``
         and named ``kwds``.
@@ -210,32 +332,65 @@ class CodeGenerator:
             with self.l('if {variable} not in {enum}:'):
                 self.l('raise JsonSchemaException("Wrong!")')
         """
-        spaces = ' ' * self.INDENT * self._indent
-
         name = self._variable_name
-        if name and '{' in name:
+        if expand_locals and '{name}' in line and name and '{' in name:
             name = '"+"{}".format(**locals())+"'.format(self._variable_name)
 
         context = dict(
             self._definition or {},
             variable=self._variable,
             name=name,
-            **kwds
+            **kwds,
         )
-        line = line.format(*args, **context)
-        line = line.replace('\n', '\\n').replace('\r', '\\r')
-        self._code.append(spaces + line)
-        return line
+        code = line.format(*args, **context)
+        code = code.replace('\n', '\\n').replace('\r', '\\r')
+        self._emit(self._indent, code, deduplicate)
 
-    def e(self, string):
+    @staticmethod
+    def e(string):
         """
         Short-cut of escape. Used for inserting user values into a string message.
 
         .. code-block:: python
-
             self.l('raise JsonSchemaException("Variable: {}")', self.e(variable))
         """
         return str(string).replace('"', '\\"')
+
+    def throw(self, message: str, *args, **kwargs):
+        """
+        Generate code for `raise JsonSchemaException(...)`
+
+        This function has two purposes:
+        - to keep the code less verbose
+        - distinguish between final validation failures and probing validation failures
+
+        :param message: string to be included in the exception
+        """
+        expand = not self.is_probing
+        if self._verbose:
+            message += '\\n  caused by {path} {rule}'
+            kwargs.update(path=self.context_path(), rule=self._definition)
+        self.l('raise JsonSchemaException("{}")'.format(message if expand else ''),
+               expand_locals=expand, *args, **kwargs)
+
+    def declare_var(self, suffix: str, initializer: str = None) -> bool:
+        """
+        Add a new variable into the current scope and initialize it if appropriate.
+
+        :param suffix: full variable name is formed by adding suffic to the variable in scope
+        :param initializer: value to initialize the variable with
+        :return: True if the variable was already declared
+        """
+        variable_name = '{}_{}'.format(self._variable, suffix)
+        result = variable_name in self._variables
+        if not result:
+            self._variables.add(variable_name)
+            if initializer is not None:
+                self.l('{} = {}'.format(variable_name, initializer))
+        return result
+
+    def create_variable_missing(self):
+        return self.declare_var('missing', '{{prop for prop in {required} if prop not in {variable}}}')
 
     def create_variable_with_length(self):
         """
@@ -244,41 +399,25 @@ class CodeGenerator:
         It can be called several times and always it's done only when that variable
         still does not exists.
         """
-        variable_name = '{}_len'.format(self._variable)
-        if variable_name in self._variables:
-            return
-        self._variables.add(variable_name)
-        self.l('{variable}_len = len({variable})')
+        return self.declare_var('len', 'len({variable})')
 
     def create_variable_keys(self):
         """
         Append code for creating variable with keys of that variable (dictionary)
         with a name ``{variable}_keys``. Similar to `create_variable_with_length`.
         """
-        variable_name = '{}_keys'.format(self._variable)
-        if variable_name in self._variables:
-            return
-        self._variables.add(variable_name)
-        self.l('{variable}_keys = set({variable}.keys())')
+        return self.declare_var('keys', 'set({variable}.keys())')
 
     def create_variable_is_list(self):
         """
         Append code for creating variable with bool if it's instance of list
         with a name ``{variable}_is_list``. Similar to `create_variable_with_length`.
         """
-        variable_name = '{}_is_list'.format(self._variable)
-        if variable_name in self._variables:
-            return
-        self._variables.add(variable_name)
-        self.l('{variable}_is_list = isinstance({variable}, list)')
+        return self.declare_var('is_list', 'isinstance({variable}, list)')
 
     def create_variable_is_dict(self):
         """
         Append code for creating variable with bool if it's instance of list
         with a name ``{variable}_is_dict``. Similar to `create_variable_with_length`.
         """
-        variable_name = '{}_is_dict'.format(self._variable)
-        if variable_name in self._variables:
-            return
-        self._variables.add(variable_name)
-        self.l('{variable}_is_dict = isinstance({variable}, dict)')
+        return self.declare_var('is_dict', 'isinstance({variable}, dict)')

--- a/fastjsonschema/indent.py
+++ b/fastjsonschema/indent.py
@@ -3,25 +3,18 @@ def indent(func):
     Decorator for allowing to use method as normal method or with
     context manager for auto-indenting code blocks.
     """
-    def wrapper(self, line, *args, optimize=True, **kwds):
-        last_line = self._indent_last_line
-        line = func(self, line, *args, **kwds)
-        # When two blocks have the same condition (such as value has to be dict),
-        # do the check only once and keep it under one block.
-        if optimize and last_line == line:
-            self._code.pop()
-        return Indent(self, line)
+    def wrapper(self, *args, **kwds):
+        func(self, *args, **kwds)
+        return Indent(self)
     return wrapper
 
 
 class Indent:
-    def __init__(self, instance, line):
+    def __init__(self, instance):
         self.instance = instance
-        self.line = line
 
     def __enter__(self):
         self.instance._indent += 1
 
     def __exit__(self, type_, value, traceback):
         self.instance._indent -= 1
-        self.instance._indent_last_line = self.line

--- a/fastjsonschema/version.py
+++ b/fastjsonschema/version.py
@@ -1,1 +1,1 @@
-VERSION = '2.13'
+VERSION = '2.12'

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -43,7 +43,7 @@ from fastjsonschema import JsonSchemaException
     ),
     (
         [9, 'hello', [1], {'a': 'a', 'x': 'x', 'y': 'y'}, 'str', 5],
-        JsonSchemaException('data[3] must contain [\'a\', \'b\'] properties'),
+        JsonSchemaException('data[3] must contain [\'b\'] properties'),
     ),
     (
         [9, 'hello', [1], {}, 'str', 5],

--- a/tests/test_object.py
+++ b/tests/test_object.py
@@ -43,10 +43,11 @@ def test_min_properties(asserter, value, expected):
     }, value, expected)
 
 
-exc = JsonSchemaException('data must contain [\'a\', \'b\'] properties')
+exc_ab = JsonSchemaException('data must contain [\'a\', \'b\'] properties')
+exc_b = JsonSchemaException('data must contain [\'b\'] properties')
 @pytest.mark.parametrize('value, expected', [
-    ({}, exc),
-    ({'a': 1}, exc),
+    ({}, exc_ab),
+    ({'a': 1}, exc_b),
     ({'a': 1, 'b': 2}, {'a': 1, 'b': 2}),
 ])
 def test_required(asserter, value, expected):


### PR DESCRIPTION
I really much appreciate the idea and code of this library. In our project we have 20 schemas linked via ref and so running a validation against invalid data gives you a puzzle work to spot the problem (whereas jsonschema library shows the problem directly). I wanted to have a better message so I came up with this patch, which among others contains:

- fixing problem can be increased by calling the CodeGenerator constructor with verbose=True
- optimizing repeated if-check-type-statements
- throwing naked JsonSchemaExceptions where the message does not really matter (like in oneOf tests)
- in `required` test, only show properties missing
- fixing small inconsistencies
