### PR TITLE
Minor correction to validate documentation

### DIFF
--- a/fastjsonschema/__init__.py
+++ b/fastjsonschema/__init__.py
@@ -95,7 +95,7 @@ def validate(definition, data, handlers={}, formats={}):
 
         import fastjsonschema
 
-        validate({'type': 'string'}, 'hello')
+        fastjsonschema.validate({'type': 'string'}, 'hello')
         # same as: compile({'type': 'string'})('hello')
 
     Preferred is to use :any:`compile` function.


### PR DESCRIPTION
This minor change to the `validate` documentation will make the example execute as written.