### PR TITLE
Preserving full path to a value when following $ref

### DIFF
--- a/tests/test_object.py
+++ b/tests/test_object.py
@@ -182,3 +182,23 @@ def test_object_with_ref_property(asserter, value, expected):
             "$ref": {"type": "string"}
         }
     }, value, expected)
+
+
+@pytest.mark.parametrize('value, expected', [
+    ({ "prop1": { "str": 1 } }, JsonSchemaException('data.prop1.str must be string', value=1, name='data.prop1.str', definition={'type': 'string'}, rule='type')),
+])
+def test_full_name_after_ref(asserter, value, expected):
+    asserter({
+        "definitions": {
+            "SomeType": {
+                "type": "object",
+                "properties": {
+                    "str": {"type": "string"},
+                },
+            },
+        },
+        "type": "object",
+        "properties": {
+            "prop1": {"$ref": "#/definitions/SomeType"},
+        }
+    }, value, expected)


### PR DESCRIPTION
This is a simple change that preserves full path to value when following $ref.

Taking this object:
```
{ "prop1": { "str": 1 } }
```
and this schema as an example:
```
{
    "definitions": {
        "SomeType": {
            "type": "object",
            "properties": {
                "str": {"type": "string"},
            },
        },
    },
    "type": "object",
    "properties": {
        "prop1": {"$ref": "#/definitions/SomeType"},
    }
}
```
Error message will now contain full path: `data.prop1.str` instead of an incorrect `data.str`.