### PR TITLE
Add expected const value to exception message

### DIFF
--- a/fastjsonschema/draft06.py
+++ b/fastjsonschema/draft06.py
@@ -182,4 +182,4 @@ class CodeGeneratorDraft06(CodeGeneratorDraft04):
         if isinstance(const, str):
             const = '"{}"'.format(const)
         with self.l('if {variable} != {}:', const):
-            self.exc('{name} must be same as const definition', rule='const')
+            self.exc('{name} must be same as const definition: {definition}', rule='const')


### PR DESCRIPTION
Based on the following schema definition example:
```
    "properties": {
      "test": {
        "const": 0
      }
    }
```

Change the resulting error message from: `fastjsonschema.exceptions.JsonSchemaException: data.test must be same as const definition` 
to `fastjsonschema.exceptions.JsonSchemaException: data.test must be same as const definition: {'const': 0}`