### PR TITLE
Validate Data Keys against Schema Definition Keys

### DIFF
--- a/fastjsonschema/draft04.py
+++ b/fastjsonschema/draft04.py
@@ -454,8 +454,19 @@ class CodeGeneratorDraft04(CodeGenerator):
         Valid object is containing key called 'key' and value any number.
         """
         self.create_variable_is_dict()
+        self.create_valid_keys()
         with self.l('if {variable}_is_dict:'):
             self.create_variable_keys()
+
+            # verify that the keys in the data are valid keys defined by the schema.
+            # any key in the data that's not defined by schema is an invalid key.
+            # if any invalid key is found, raise JsonSchemaException.
+            with self.l('for data_key in {variable}_keys:'):
+                with self.l('if data_key in valid_keys_{variable}:'):
+                    self.l('continue')
+                with self.l('else:'):
+                    self.exc("{variable} contains invalid key." , self.e(self._variable_name), rule='properties')
+
             for key, prop_definition in self._definition['properties'].items():
                 key_name = re.sub(r'($[^a-zA-Z]|[^a-zA-Z0-9])', '', key)
                 if not isinstance(prop_definition, (dict, bool)):

--- a/fastjsonschema/generator.py
+++ b/fastjsonschema/generator.py
@@ -272,6 +272,33 @@ class CodeGenerator:
         self._variables.add(variable_name)
         self.l('{variable}_keys = set({variable}.keys())')
 
+
+    def create_valid_keys(self):
+        """
+        Append code for creating a variable containing keys that are
+        valid keys for the property as specified by the provided schema definition.
+
+        Each one of the ``{variable}_keys`` must be present in the ``valid_keys_{variable}`` for the provided data to be valid.
+
+        Example: 
+
+        if the schema definition is: 
+        {"type":"object", "properties":{"email":{"type":"string","minLength":3}}},
+        then:
+
+        data1 = {"email":"threeChars@email.com"} is valid 
+        but
+        data2 = {"emale":"threeChars@email.com"} is invalid
+
+        because the schema definition does not permit a (property) key named "emale".
+        """
+        variable_name = 'valid_keys_{}'.format(self._variable)
+
+        if variable_name in self._variables:
+            return
+        self._variables.add(variable_name)
+        self.l('valid_keys_{} = {}'.format(self._variable,list(self._definition['properties'].keys())))
+
     def create_variable_is_list(self):
         """
         Append code for creating variable with bool if it's instance of list


### PR DESCRIPTION
Generated Code: updated the generator and Draft04 code to throw a JsonSchemaException in the generated validation function when the provided data properties contain key(s) not defined by the schema definition.