### PR TITLE
additionalProperties == {} equivalent to True

### DIFF
--- a/fastjsonschema/draft04.py
+++ b/fastjsonschema/draft04.py
@@ -524,7 +524,7 @@ class CodeGeneratorDraft04(CodeGenerator):
         with self.l('if {variable}_is_dict:'):
             self.create_variable_keys()
             add_prop_definition = self._definition["additionalProperties"]
-            if add_prop_definition == True:
+            if add_prop_definition is True or add_prop_definition == {}:
                 return
             elif add_prop_definition:
                 properties_keys = list(self._definition.get("properties", {}).keys())

--- a/tests/test_object.py
+++ b/tests/test_object.py
@@ -159,6 +159,28 @@ def test_additional_properties(asserter, value, expected):
 
 
 @pytest.mark.parametrize('value, expected', [
+    ({}, {}),
+    ({'a': 1}, {'a': 1}),
+    ({'b': True}, {'b': True}),
+    ({'c': ''}, {'c': ''}),
+    ({'d': 1}, {'d': 1}),
+    ({'e': {'test': 'x'}}, {'e': {'test': 'x'}}),
+    ({'g': [1, 2, 3]}, {'g': [1, 2, 3]}),
+    ({'h': False}, {'h': False}),
+])
+def test_any_additional_properties(asserter, value, expected):
+    for obj in (True, {}):
+        asserter({
+            'type': 'object',
+            "properties": {
+                "a": {"type": "number"},
+                "b": {"type": "boolean"},
+            },
+            "additionalProperties": obj
+        }, value, expected)
+
+
+@pytest.mark.parametrize('value, expected', [
     ({'id': 1}, {'id': 1}),
     ({'id': 'a'}, JsonSchemaException('data.id must be integer', value='a', name='data.id', definition={'type': 'integer'}, rule='type')),
 ])


### PR DESCRIPTION
see spec https://swagger.io/docs/specification/data-models/dictionaries/

![image](https://user-images.githubusercontent.com/8166963/105905778-e9615200-6033-11eb-920b-72bae9c87a9e.png)
