### PR TITLE
Reconstruct regexes in generated code

### DIFF
--- a/fastjsonschema/generator.py
+++ b/fastjsonschema/generator.py
@@ -1,6 +1,5 @@
 from collections import OrderedDict
 import re
-import pickle
 
 from .exceptions import JsonSchemaValueException, JsonSchemaDefinitionException
 from .indent import indent
@@ -101,12 +100,16 @@ class CodeGenerator:
                 '',
                 '',
             ])
+        regex_patterns = (
+            repr(k) + ": " + _repr_regex(v)
+            for k, v in self._compile_regexps.items()
+        )
         return '\n'.join(self._extra_imports_lines + [
-            'import re, pickle',
+            'import re',
             'from fastjsonschema import JsonSchemaValueException',
             '',
             '',
-            'REGEX_PATTERNS = pickle.loads(' + str(pickle.dumps(self._compile_regexps)) + ')',
+            'REGEX_PATTERNS = {\n    ' + ",\n    ".join(regex_patterns) + "\n}",
             '',
         ])
 
@@ -293,3 +296,7 @@ class CodeGenerator:
             return
         self._variables.add(variable_name)
         self.l('{variable}_is_dict = isinstance({variable}, dict)')
+
+
+def _repr_regex(regex):
+    return "re.compile({!r}, {!r})".format(regex.pattern, regex.flags)

--- a/fastjsonschema/generator.py
+++ b/fastjsonschema/generator.py
@@ -101,7 +101,7 @@ class CodeGenerator:
                 '',
             ])
         regex_patterns = (
-            repr(k) + ": " + _repr_regex(v)
+            repr(k) + ": " + repr_regex(v)
             for k, v in self._compile_regexps.items()
         )
         return '\n'.join(self._extra_imports_lines + [
@@ -298,5 +298,9 @@ class CodeGenerator:
         self.l('{variable}_is_dict = isinstance({variable}, dict)')
 
 
-def _repr_regex(regex):
-    return "re.compile({!r}, {!r})".format(regex.pattern, regex.flags)
+def repr_regex(regex):
+    # Unfortunately using `pprint.pformat` is causing errors
+    all_flags = ("A", "I", "DEBUG", "L", "M", "S", "X")
+    flags = " | ".join(f"re.{f}" for f in all_flags if regex.flags & getattr(re, f))
+    flags = ", " + flags if flags else ""
+    return "re.compile({!r}{})".format(regex.pattern, flags)


### PR DESCRIPTION
Previously, regexes where being pickled in generated code, which makes it more difficult to understand and debug.

To improve this situation, this change proposes reconstructing the call to the `re.compile` function.

It should have no affect in the code executed via `compile`, just on the code generated via `compile_to_code`.