### PR TITLE
Fix unexpected caching (issue #129)

### DIFF
--- a/fastjsonschema/__init__.py
+++ b/fastjsonschema/__init__.py
@@ -213,7 +213,7 @@ def compile_to_code(definition, handlers={}, formats={}, use_default=True):
 
 
 def _factory(definition, handlers, formats={}, use_default=True):
-    resolver = RefResolver.from_schema(definition, handlers=handlers)
+    resolver = RefResolver.from_schema(definition, handlers=handlers, store={})
     code_generator = _get_code_generator_class(definition)(
         definition,
         resolver=resolver,

--- a/fastjsonschema/generator.py
+++ b/fastjsonschema/generator.py
@@ -54,7 +54,7 @@ class CodeGenerator:
         self._validation_functions_done = set()
 
         if resolver is None:
-            resolver = RefResolver.from_schema(definition)
+            resolver = RefResolver.from_schema(definition, store={})
         self._resolver = resolver
 
         # add main function to `self._needed_validation_functions`

--- a/fastjsonschema/ref_resolver.py
+++ b/fastjsonschema/ref_resolver.py
@@ -77,12 +77,19 @@ class RefResolver:
     def __init__(self, base_uri, schema, store={}, cache=True, handlers={}):
         """
         `base_uri` is URI of the referring document from the `schema`.
+        `store` is an dictionary that will be used to cache the fetched schemas
+        (if `cache=True`).
+
+        Please notice that you can have caching problems when compiling schemas
+        with colliding `$ref`. To force overwriting use `cache=False` or
+        explicitly pass the `store` argument (with a brand new dictionary)
         """
         self.base_uri = base_uri
         self.resolution_scope = base_uri
         self.schema = schema
         self.store = store
         self.cache = cache
+        # ^-- Create a brand new cache if the 
         self.handlers = handlers
         self.walk(schema)
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,6 +1,6 @@
 import pytest
 
-from fastjsonschema import JsonSchemaValueException
+from fastjsonschema import JsonSchemaValueException, compile
 
 
 definition = {
@@ -127,3 +127,18 @@ def test_any_of_with_patterns(asserter):
     }, {
         'hash': 'AAAXXX',
     })
+
+
+def test_swap_handlers():
+    # Make sure that by swapping resolvers, the schemas do not get cached
+    repo1 = {
+        "sch://schema": {"type": "array"}
+    }
+    validator1 = compile({"$ref": "sch://schema"}, handlers={"sch": repo1.__getitem__})
+    assert validator1([1, 2, 3]) is not None
+
+    repo2 = {
+        "sch://schema": {"type": "string"}
+    }
+    validator2 = compile({"$ref": "sch://schema"}, handlers={"sch": repo2.__getitem__})
+    assert validator2("hello world") is not None


### PR DESCRIPTION
This PR is an attempt to fix #129.

The approach adopted here was to replace all the empty dictionaries used as mutable default arguments with `None` and use the handy `self.value = value or {}` expression to make sure we have an empty default dictionary...