### PR TITLE
Preserving full path to a value when following $ref

### DIFF
--- a/fastjsonschema/exceptions.py
+++ b/fastjsonschema/exceptions.py
@@ -16,8 +16,8 @@ class JsonSchemaValueException(JsonSchemaException):
 
      * ``message`` containing human-readable information what is wrong (e.g. ``data.property[index] must be smaller than or equal to 42``),
      * invalid ``value`` (e.g. ``60``),
-     * ``name`` of a path in the data structure (e.g. ``data.propery[index]``),
-     * ``path`` as an array in the data structure (e.g. ``['data', 'propery', 'index']``),
+     * ``name`` of a path in the data structure (e.g. ``data.property[index]``),
+     * ``path`` as an array in the data structure (e.g. ``['data', 'property', 'index']``),
      * the whole ``definition`` which the ``value`` has to fulfil (e.g. ``{'type': 'number', 'maximum': 42}``),
      * ``rule`` which the ``value`` is breaking (e.g. ``maximum``)
      * and ``rule_definition`` (e.g. ``42``).

--- a/fastjsonschema/generator.py
+++ b/fastjsonschema/generator.py
@@ -136,7 +136,7 @@ class CodeGenerator:
         self._validation_functions_done.add(uri)
         self.l('')
         with self._resolver.resolving(uri) as definition:
-            with self.l('def {}(data, custom_formats={{}}):', name):
+            with self.l('def {}(data, custom_formats={{}}, name_prefix=None):', name):
                 self.generate_func_code_block(definition, 'data', 'data', clear_variables=True)
                 self.l('return data')
 
@@ -190,7 +190,9 @@ class CodeGenerator:
             if uri not in self._validation_functions_done:
                 self._needed_validation_functions[uri] = name
             # call validation function
-            self.l('{}({variable}, custom_formats)', name)
+            path = self._variable_name[4:]
+            name_arg = '(name_prefix or "data") + "{}"'.format(path)
+            self.l('{}({variable}, custom_formats, {name_arg})', name, name_arg=name_arg)
 
 
     # pylint: disable=invalid-name
@@ -216,8 +218,12 @@ class CodeGenerator:
         spaces = ' ' * self.INDENT * self._indent
 
         name = self._variable_name
-        if name and '{' in name:
-            name = '"+"{}".format(**locals())+"'.format(self._variable_name)
+        if name:
+            # Add name_prefix to the name when it is being outputted.
+            assert name.startswith('data')
+            name = '" + (name_prefix or "data") + "' + name[4:]
+            if '{' in name:
+                name = name + '".format(**locals()) + "'
 
         context = dict(
             self._definition or {},

--- a/fastjsonschema/generator.py
+++ b/fastjsonschema/generator.py
@@ -190,6 +190,7 @@ class CodeGenerator:
             if uri not in self._validation_functions_done:
                 self._needed_validation_functions[uri] = name
             # call validation function
+            assert self._variable_name.startswith("data")
             path = self._variable_name[4:]
             name_arg = '(name_prefix or "data") + "{}"'.format(path)
             self.l('{}({variable}, custom_formats, {name_arg})', name, name_arg=name_arg)

--- a/tests/test_compile_to_code.py
+++ b/tests/test_compile_to_code.py
@@ -121,4 +121,4 @@ def test_compile_to_code_custom_format_with_refs():
     assert validate({"a": ["identifier"]}, formats) is not None
     with pytest.raises(JsonSchemaValueException) as exc:
         validate({"a": ["identifier", "not-valid"]}, formats)
-    assert exc.value.message == "data[1] must be my-format"
+    assert exc.value.message == "data.a[1] must be my-format"

--- a/tests/test_object.py
+++ b/tests/test_object.py
@@ -226,3 +226,23 @@ def test_dependencies(asserter, value, expected):
             "foo": ["bar"],
         },
     }, value, expected)
+
+
+@pytest.mark.parametrize('value, expected', [
+    ({"prop1": {"str": 1}}, JsonSchemaValueException('data.prop1.str must be string', value=1, name='data.prop1.str', definition={'type': 'string'}, rule='type')),
+])
+def test_full_name_after_ref(asserter, value, expected):
+    asserter({
+        "definitions": {
+            "SomeType": {
+                "type": "object",
+                "properties": {
+                    "str": {"type": "string"},
+                },
+            },
+        },
+        "type": "object",
+        "properties": {
+            "prop1": {"$ref": "#/definitions/SomeType"},
+        }
+    }, value, expected)


### PR DESCRIPTION
This is just a "rebased" version of https://github.com/horejsek/python-fastjsonschema/pull/92, that can be compared and rebased into master.

I think this approach is really useful when debugging errors. More than once I found myself trying to understand which property exactly was failing. Preserving the complete path make is less confusing and more straight forward to find the errors.

All the work was done by @ZbigniewRA in #92.

Potentially, this closes #63.