### PR TITLE
Expand `$ref` when assigning the `definition` field to `JsonSchemaValueException`

### DIFF
--- a/fastjsonschema/generator.py
+++ b/fastjsonschema/generator.py
@@ -245,8 +245,27 @@ class CodeGenerator:
         Short-cut for creating raising exception in the code.
         """
         msg = 'raise JsonSchemaValueException("'+msg+'", value={variable}, name="{name}", definition={definition}, rule={rule})'
-        definition_rule = self.e(self._definition.get(rule) if isinstance(self._definition, dict) else None)
-        self.l(msg, *args, definition=repr(self._definition), rule=repr(rule), definition_rule=definition_rule)
+        definition = self._expand_refs(self._definition)
+        definition_rule = self.e(definition.get(rule) if isinstance(definition, dict) else None)
+        self.l(msg, *args, definition=repr(definition), rule=repr(rule), definition_rule=definition_rule)
+
+    def _expand_refs(self, definition):
+        if isinstance(definition, list):
+            return [self._expand_refs(v) for v in definition]
+        if not isinstance(definition, dict):
+            return definition
+        if "$ref" in definition:
+            with self._resolver.resolving(definition["$ref"]) as schema:
+                return schema
+        if "properties" in definition:
+            return {
+                **definition,
+                "properties": {
+                    k: self._expand_refs(v)
+                    for k, v in definition["properties"].items()
+                }
+            }
+        return {k: self._expand_refs(v) for k, v in definition.items()}
 
     def create_variable_with_length(self):
         """

--- a/fastjsonschema/generator.py
+++ b/fastjsonschema/generator.py
@@ -254,17 +254,9 @@ class CodeGenerator:
             return [self._expand_refs(v) for v in definition]
         if not isinstance(definition, dict):
             return definition
-        if "$ref" in definition:
+        if "$ref" in definition and isinstance(definition["$ref"], str):
             with self._resolver.resolving(definition["$ref"]) as schema:
                 return schema
-        if "properties" in definition:
-            return {
-                **definition,
-                "properties": {
-                    k: self._expand_refs(v)
-                    for k, v in definition["properties"].items()
-                }
-            }
         return {k: self._expand_refs(v) for k, v in definition.items()}
 
     def create_variable_with_length(self):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,7 +33,8 @@ def asserter():
         if isinstance(expected, JsonSchemaValueException):
             with pytest.raises(JsonSchemaValueException) as exc:
                 validator(value)
-            assert exc.value.message == expected.message
+            if expected.message is not any:
+                assert exc.value.message == expected.message
             assert exc.value.value == (value if expected.value == '{data}' else expected.value)
             assert exc.value.name == expected.name
             assert exc.value.definition == (definition if expected.definition == '{definition}' else expected.definition)

--- a/tests/examples/conditional/address.schema.json
+++ b/tests/examples/conditional/address.schema.json
@@ -1,0 +1,21 @@
+{
+  "type": "object",
+  "properties": {
+    "street_address": {
+      "type": "string"
+    },
+    "country": {
+      "default": "United States of America",
+      "enum": ["United States of America", "Canada"]
+    }
+  },
+  "if": {
+    "properties": { "country": { "const": "United States of America" } }
+  },
+  "then": {
+    "properties": { "postal_code": { "pattern": "[0-9]{5}(-[0-9]{4})?" } }
+  },
+  "else": {
+    "properties": { "postal_code": { "pattern": "[A-Z][0-9][A-Z] [0-9][A-Z][0-9]" } }
+  }
+}

--- a/tests/examples/conditional/invalid.error
+++ b/tests/examples/conditional/invalid.error
@@ -1,0 +1,1 @@
+data.postal_code must match pattern [A-Z][0-9][A-Z] [0-9][A-Z][0-9]

--- a/tests/examples/conditional/invalid.json
+++ b/tests/examples/conditional/invalid.json
@@ -1,0 +1,5 @@
+{
+  "street_address": "24 Sussex Drive",
+  "country": "Canada",
+  "postal_code": "10000"
+}

--- a/tests/examples/conditional/valid.json
+++ b/tests/examples/conditional/valid.json
@@ -1,0 +1,5 @@
+{
+  "street_address": "1600 Pennsylvania Avenue NW",
+  "country": "United States of America",
+  "postal_code": "20500"
+}

--- a/tests/test_composition.py
+++ b/tests/test_composition.py
@@ -1,0 +1,78 @@
+import pytest
+
+import fastjsonschema
+from fastjsonschema import JsonSchemaValueException
+
+
+def _composition_example(composition="oneOf"):
+    return {
+        "definitions": {
+            "multiple-of-3": {"type": "number", "multipleOf": 3},
+            "multiple-of-5": {"type": "number", "multipleOf": 5},
+        },
+        composition: [
+            {"$ref": "#/definitions/multiple-of-3"},
+            {"$ref": "#/definitions/multiple-of-5"},
+        ],
+    }
+
+
+@pytest.mark.parametrize(
+    "composition, value",
+    [("oneOf", 10), ("allOf", 15), ("anyOf", 9)]
+)
+def test_composition(asserter, composition, value):
+    asserter(_composition_example(composition), value, value)
+
+
+@pytest.mark.parametrize(
+    "composition, value",
+    [("oneOf", 2), ("anyOf", 2), ("allOf", 3)]
+)
+def test_ref_is_expanded_on_composition_error(composition, value):
+    with pytest.raises(JsonSchemaValueException) as exc:
+        fastjsonschema.validate(_composition_example(composition), value)
+
+    if composition in exc.value.definition:
+        assert exc.value.definition[composition] == [
+            {"type": "number", "multipleOf": 3},
+            {"type": "number", "multipleOf": 5},
+        ]
+    else:
+        # allOf will fail on the first invalid item,
+        # so the error message will not refer to the entire composition
+        assert composition == "allOf"
+        assert "$ref" not in exc.value.definition
+        assert exc.value.definition["type"] == "number"
+
+
+@pytest.mark.parametrize(
+    "composition, value",
+    [("oneOf", 2), ("anyOf", 2), ("allOf", 3)]
+)
+def test_ref_is_expanded_with_resolver(composition, value):
+    repo = {
+        "sch://multiple-of-3": {"type": "number", "multipleOf": 3},
+        "sch://multiple-of-5": {"type": "number", "multipleOf": 5},
+    }
+    schema = {
+        composition: [
+            {"$ref": "sch://multiple-of-3"},
+            {"$ref": "sch://multiple-of-5"},
+        ]
+    }
+
+    with pytest.raises(JsonSchemaValueException) as exc:
+        fastjsonschema.validate(schema, value, handlers={"sch": repo.__getitem__})
+
+    if composition in exc.value.definition:
+        assert exc.value.definition[composition] == [
+            {"type": "number", "multipleOf": 3},
+            {"type": "number", "multipleOf": 5},
+        ]
+    else:
+        # allOf will fail on the first invalid item,
+        # so the error message will not refer to the entire composition
+        assert composition == "allOf"
+        assert "$ref" not in exc.value.definition
+        assert exc.value.definition["type"] == "number"


### PR DESCRIPTION
This change should fix #141.

By expanding any `$ref` field in the schema definition that is available in the `JsonSchemaValueException` objects, we make it easier for the API consumers to provide more meaningful errors.