### PR TITLE
Prevent items generator to create an empty for-loop (issue 114)

### DIFF
--- a/fastjsonschema/draft04.py
+++ b/fastjsonschema/draft04.py
@@ -413,19 +413,23 @@ class CodeGeneratorDraft04(CodeGenerator):
                             self.exc('{name} must contain only specified items', rule='items')
                     else:
                         with self.l('for {variable}_x, {variable}_item in enumerate({variable}[{0}:], {0}):', len(items_definition)):
-                            self.generate_func_code_block(
+                            count = self.generate_func_code_block(
                                 self._definition['additionalItems'],
                                 '{}_item'.format(self._variable),
                                 '{}[{{{}_x}}]'.format(self._variable_name, self._variable),
                             )
+                            if count == 0:
+                                self.l('pass')
             else:
                 if items_definition:
                     with self.l('for {variable}_x, {variable}_item in enumerate({variable}):'):
-                        self.generate_func_code_block(
+                        count = self.generate_func_code_block(
                             items_definition,
                             '{}_item'.format(self._variable),
                             '{}[{{{}_x}}]'.format(self._variable_name, self._variable),
                         )
+                        if count == 0:
+                            self.l('pass')
 
     def generate_min_properties(self):
         self.create_variable_is_dict()

--- a/fastjsonschema/generator.py
+++ b/fastjsonschema/generator.py
@@ -143,6 +143,8 @@ class CodeGenerator:
     def generate_func_code_block(self, definition, variable, variable_name, clear_variables=False):
         """
         Creates validation rules for current definition.
+
+        Returns the number of validation rules generated as code.
         """
         backup = self._definition, self._variable, self._variable_name
         self._definition, self._variable, self._variable_name = definition, variable, variable_name
@@ -150,25 +152,31 @@ class CodeGenerator:
             backup_variables = self._variables
             self._variables = set()
 
-        self._generate_func_code_block(definition)
+        count = self._generate_func_code_block(definition)
 
         self._definition, self._variable, self._variable_name = backup
         if clear_variables:
             self._variables = backup_variables
+
+        return count
 
     def _generate_func_code_block(self, definition):
         if not isinstance(definition, dict):
             raise JsonSchemaDefinitionException("definition must be an object")
         if '$ref' in definition:
             # needed because ref overrides any sibling keywords
-            self.generate_ref()
+            return self.generate_ref()
         else:
-            self.run_generate_functions(definition)
+            return self.run_generate_functions(definition)
 
     def run_generate_functions(self, definition):
+        """Returns the number of generate functions that were executed."""
+        count = 0
         for key, func in self._json_keywords_to_function.items():
             if key in definition:
                 func()
+                count += 1
+        return count
 
     def generate_ref(self):
         """

--- a/tests/test_array.py
+++ b/tests/test_array.py
@@ -180,3 +180,22 @@ def test_mixed_arrays(asserter, value, expected):
         },
     }, value, expected)
 
+
+def test_issue_114(asserter):
+    """Prevent the faulty scheme to generate an empty for-loop."""
+    schema = {
+        "type": "object",
+        "properties": {
+            "a": {
+                "type": "array",
+                "items": {
+                    "b": {
+                        "type": "string"
+                    }
+                }
+            }
+        }
+    }
+    value = {"a": []}
+    expected = value
+    asserter(schema, value, expected)


### PR DESCRIPTION
Fix #114.

In #114, the faulty schema does not provide any validation the array items, despite of explicitly having "items" as a non-empty dict.

This results in a generated empty for-loop, which in turn will result in an `IndentationError` when evaluated by Python.

In this PR, I propose to fill the empty for-loop with a `pass` statement.