### PR TITLE
Improve error message for `oneOf`, `anyOf` and `not` (slightly)

### DIFF
--- a/fastjsonschema/draft04.py
+++ b/fastjsonschema/draft04.py
@@ -211,13 +211,13 @@ class CodeGeneratorDraft04(CodeGenerator):
             return
         elif not not_definition:
             with self.l('if {}:', self._variable):
-                self.exc('{name} must not be valid by not definition', rule='not')
+                self.exc('{name} must NOT match a disallowed definition', rule='not')
         else:
             with self.l('try:', optimize=False):
                 self.generate_func_code_block(not_definition, self._variable, self._variable_name)
             self.l('except JsonSchemaValueException: pass')
             with self.l('else:'):
-                self.exc('{name} must not be valid by not definition', rule='not')
+                self.exc('{name} must NOT match a disallowed definition', rule='not')
 
     def generate_min_length(self):
         with self.l('if isinstance({variable}, str):'):

--- a/fastjsonschema/draft04.py
+++ b/fastjsonschema/draft04.py
@@ -158,7 +158,7 @@ class CodeGeneratorDraft04(CodeGenerator):
                 self.l('except JsonSchemaValueException: pass')
 
         with self.l('if not {variable}_any_of_count{count}:', count=count, optimize=False):
-            self.exc('{name} must be valid by one of anyOf definition', rule='anyOf')
+            self.exc('{name} cannot be validated by any definition', rule='anyOf')
 
     def generate_one_of(self):
         """
@@ -188,7 +188,8 @@ class CodeGeneratorDraft04(CodeGenerator):
                 self.l('except JsonSchemaValueException: pass')
 
         with self.l('if {variable}_one_of_count{count} != 1:', count=count):
-            self.exc('{name} must be valid exactly by one of oneOf definition', rule='oneOf')
+            dynamic = '" (" + str({variable}_one_of_count{}) + " matches found)"'
+            self.exc('{name} must be valid exactly by one definition', count, append_to_msg=dynamic, rule='oneOf')
 
     def generate_not(self):
         """

--- a/fastjsonschema/generator.py
+++ b/fastjsonschema/generator.py
@@ -247,11 +247,14 @@ class CodeGenerator:
         """
         return str(string).replace('"', '\\"')
 
-    def exc(self, msg, *args, rule=None):
+    def exc(self, msg, *args, append_to_msg=None, rule=None):
         """
         Short-cut for creating raising exception in the code.
         """
-        msg = 'raise JsonSchemaValueException("'+msg+'", value={variable}, name="{name}", definition={definition}, rule={rule})'
+        arg = '"'+msg+'"'
+        if append_to_msg:
+            arg += ' + (' + append_to_msg + ')'
+        msg = 'raise JsonSchemaValueException('+arg+', value={variable}, name="{name}", definition={definition}, rule={rule})'
         definition = self._expand_refs(self._definition)
         definition_rule = self.e(definition.get(rule) if isinstance(definition, dict) else None)
         self.l(msg, *args, definition=repr(definition), rule=repr(rule), definition_rule=definition_rule)

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -91,7 +91,7 @@ def test_one_of_factorized(asserter, value, expected):
 
 
 @pytest.mark.parametrize('value, expected', [
-    (0, JsonSchemaValueException('data must not be valid by not definition', value='{data}', name='data', definition='{definition}', rule='not')),
+    (0, JsonSchemaValueException('data must NOT match a disallowed definition', value='{data}', name='data', definition='{definition}', rule='not')),
     (True, True),
     ('abc', 'abc'),
     ([], []),

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -39,7 +39,7 @@ def test_all_of(asserter, value, expected):
     ]}, value, expected)
 
 
-exc = JsonSchemaValueException('data must be valid by one of anyOf definition', value='{data}', name='data', definition='{definition}', rule='anyOf')
+exc = JsonSchemaValueException('data cannot be validated by any definition', value='{data}', name='data', definition='{definition}', rule='anyOf')
 @pytest.mark.parametrize('value, expected', [
     (0, 0),
     (None, exc),
@@ -55,13 +55,16 @@ def test_any_of(asserter, value, expected):
     ]}, value, expected)
 
 
-exc = JsonSchemaValueException('data must be valid exactly by one of oneOf definition', value='{data}', name='data', definition='{definition}', rule='oneOf')
+def exc(n):
+    suffix = " ({} matches found)".format(n)
+    return JsonSchemaValueException('data must be valid exactly by one definition' + suffix, value='{data}', name='data', definition='{definition}', rule='oneOf')
+
 @pytest.mark.parametrize('value, expected', [
-    (0, exc),
-    (2, exc),
+    (0, exc(2)),
+    (2, exc(0)),
     (9, 9),
     (10, 10),
-    (15, exc),
+    (15, exc(2)),
 ])
 def test_one_of(asserter, value, expected):
     asserter({'oneOf': [
@@ -70,13 +73,12 @@ def test_one_of(asserter, value, expected):
     ]}, value, expected)
 
 
-exc = JsonSchemaValueException('data must be valid exactly by one of oneOf definition', value='{data}', name='data', definition='{definition}', rule='oneOf')
 @pytest.mark.parametrize('value, expected', [
-    (0, exc),
-    (2, exc),
+    (0, exc(2)),
+    (2, exc(0)),
     (9, 9),
     (10, 10),
-    (15, exc),
+    (15, exc(2)),
 ])
 def test_one_of_factorized(asserter, value, expected):
     asserter({

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -94,7 +94,7 @@ definition = {
     ),
     (
         [9, 'hello', [1], {'a': 'a', 'b': 'b', 'x': 'x'}, None, 5],
-        JsonSchemaValueException('data[4] must not be valid by not definition', value=None, name='data[4]', definition=definition['items'][4], rule='not'),
+        JsonSchemaValueException('data[4] must NOT match a disallowed definition', value=None, name='data[4]', definition=definition['items'][4], rule='not'),
     ),
     (
         [9, 'hello', [1], {'a': 'a', 'b': 'b', 'x': 'x'}, 42, 15],

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -98,7 +98,7 @@ definition = {
     ),
     (
         [9, 'hello', [1], {'a': 'a', 'b': 'b', 'x': 'x'}, 42, 15],
-        JsonSchemaValueException('data[5] must be valid exactly by one of oneOf definition', value=15, name='data[5]', definition=definition['items'][5], rule='oneOf'),
+        JsonSchemaValueException('data[5] must be valid exactly by one definition (2 matches found)', value=15, name='data[5]', definition=definition['items'][5], rule='oneOf'),
     ),
 ])
 def test_integration(asserter, value, expected):


### PR DESCRIPTION
In https://github.com/horejsek/python-fastjsonschema/pull/142#issuecomment-1050814835 I asked if the author would be interested in some error message improvements, so I experimented a bit with making some changes to the errors.

My original idea was to use the definition to generate a little summary of what is expected. However that would add a lot of complexity, and I don't think that is a good approach... So instead I tried to improve 2 of them (very slightly).

Currently, the error messages of `oneOf`, `anyOf` and `not` (when analysed without the definition JSON) don't read so well. For example:

```
data must be valid exactly by one of oneOf definition
data must be valid by one of anyOf definition
data must not be valid by not definition
```

In this PR I am proposing changing a little bit these messages so they read slightly better:

```diff
- data must be valid exactly by one of oneOf definition
+ data must be valid exactly by one definition ({N} matches found)

- data must be valid by one of anyOf definition
+ data cannot be validated by any definition

- data must not be valid by not definition
+ data must NOT match a disallowed definition
```

I understand that this change is very superficial, so please feel free to simply close the PR.