### PR TITLE
Update python support metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,8 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: Implementation :: CPython",
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',

--- a/setup.py
+++ b/setup.py
@@ -41,8 +41,8 @@ setup(
     license='BSD',
 
     classifiers=[
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 3',
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.3",
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
@@ -52,10 +52,10 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: Implementation :: CPython",
-        'License :: OSI Approved :: BSD License',
-        'Operating System :: OS Independent',
-        'Development Status :: 5 - Production/Stable',
-        'Intended Audience :: Developers',
-        'Topic :: Software Development :: Libraries :: Python Modules',
+        "License :: OSI Approved :: BSD License",
+        "Operating System :: OS Independent",
+        "Development Status :: 5 - Production/Stable",
+        "Intended Audience :: Developers",
+        "Topic :: Software Development :: Libraries :: Python Modules",
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py{34,35,36,37},lint
+envlist = py{34,35,36,37,38,39,310},lint
 
 [testenv]
 deps =


### PR DESCRIPTION
Looking at the github workflows that are defined it seems like python 3.9 and 3.10 are supported but just not listed in the setup.py metadata

https://github.com/horejsek/python-fastjsonschema/blob/1aad747bab39d4b1201ab99917463f4079955ecd/.github/workflows/tests.yml#L18

