### PR TITLE
fixes #157 - Add a new generator function `create_variable_with_items…

### DIFF
--- a/fastjsonschema/draft04.py
+++ b/fastjsonschema/draft04.py
@@ -326,8 +326,8 @@ class CodeGeneratorDraft04(CodeGenerator):
         with self.l('if {variable}_is_list:'):
             if not isinstance(self._definition['minItems'], int):
                 raise JsonSchemaDefinitionException('minItems must be a number')
-            self.create_variable_with_length()
-            with self.l('if {variable}_len < {minItems}:'):
+            self.create_variable_with_items()
+            with self.l('if {variable}_items < {minItems}:'):
                 self.exc('{name} must contain at least {minItems} items', rule='minItems')
 
     def generate_max_items(self):
@@ -335,8 +335,8 @@ class CodeGeneratorDraft04(CodeGenerator):
         with self.l('if {variable}_is_list:'):
             if not isinstance(self._definition['maxItems'], int):
                 raise JsonSchemaDefinitionException('maxItems must be a number')
-            self.create_variable_with_length()
-            with self.l('if {variable}_len > {maxItems}:'):
+            self.create_variable_with_items()
+            with self.l('if {variable}_items > {maxItems}:'):
                 self.exc('{name} must contain less than or equal to {maxItems} items', rule='maxItems')
 
     def generate_unique_items(self):

--- a/fastjsonschema/generator.py
+++ b/fastjsonschema/generator.py
@@ -290,6 +290,19 @@ class CodeGenerator:
         self._variables.add(variable_name)
         self.l('{variable}_len = len({variable})')
 
+    def create_variable_with_items(self):
+        """
+        Append code for creating variable with number of items (length) of that variable
+        (for example length of list or dictionary) with name ``{variable}_len``.
+        It can be called several times and always it's done only when that variable
+        still does not exists.
+        """
+        variable_name = '{}_items'.format(self._variable)
+        if variable_name in self._variables:
+            return
+        self._variables.add(variable_name)
+        self.l('{variable}_items = len({variable})')
+
     def create_variable_keys(self):
         """
         Append code for creating variable with keys of that variable (dictionary)

--- a/fastjsonschema/generator.py
+++ b/fastjsonschema/generator.py
@@ -293,7 +293,7 @@ class CodeGenerator:
     def create_variable_with_items(self):
         """
         Append code for creating variable with number of items (length) of that variable
-        (for example length of list or dictionary) with name ``{variable}_len``.
+        (for example length of list or dictionary) with name ``{variable}_items``.
         It can be called several times and always it's done only when that variable
         still does not exists.
         """


### PR DESCRIPTION
fixes #157 - Add a new generator function `create_variable_with_items` similar to `create_variable_with_length` which defines a variable `{variable}_items` insteaf of `{variable}_len` and call this function from `generate_min_items/generate_max_items` in `draft04.py`. This resolves a variable name (`{variable}_len`) conflict when one of `minItems/maxItems` is defined along with one of `minLength/maxLength` since these validations are intended for different data types.