### PR TITLE
Add support for `decimal.Decimal` as number

### DIFF
--- a/fastjsonschema/draft04.py
+++ b/fastjsonschema/draft04.py
@@ -8,7 +8,7 @@ from .generator import CodeGenerator, enforce_list
 JSON_TYPE_TO_PYTHON_TYPE = {
     'null': 'NoneType',
     'boolean': 'bool',
-    'number': 'int, float',
+    'number': 'int, float, Decimal',
     'integer': 'int',
     'string': 'str',
     'array': 'list, tuple',
@@ -285,8 +285,8 @@ class CodeGeneratorDraft04(CodeGenerator):
                 self.exc('{name} must be {}', format_name, rule='format')
 
     def generate_minimum(self):
-        with self.l('if isinstance({variable}, (int, float)):'):
-            if not isinstance(self._definition['minimum'], (int, float)):
+        with self.l('if isinstance({variable}, (int, float, Decimal)):'):
+            if not isinstance(self._definition['minimum'], (int, float, decimal.Decimal)):
                 raise JsonSchemaDefinitionException('minimum must be a number')
             if self._definition.get('exclusiveMinimum', False):
                 with self.l('if {variable} <= {minimum}:'):
@@ -296,8 +296,8 @@ class CodeGeneratorDraft04(CodeGenerator):
                     self.exc('{name} must be bigger than or equal to {minimum}', rule='minimum')
 
     def generate_maximum(self):
-        with self.l('if isinstance({variable}, (int, float)):'):
-            if not isinstance(self._definition['maximum'], (int, float)):
+        with self.l('if isinstance({variable}, (int, float, Decimal)):'):
+            if not isinstance(self._definition['maximum'], (int, float, decimal.Decimal)):
                 raise JsonSchemaDefinitionException('maximum must be a number')
             if self._definition.get('exclusiveMaximum', False):
                 with self.l('if {variable} >= {maximum}:'):
@@ -307,14 +307,12 @@ class CodeGeneratorDraft04(CodeGenerator):
                     self.exc('{name} must be smaller than or equal to {maximum}', rule='maximum')
 
     def generate_multiple_of(self):
-        with self.l('if isinstance({variable}, (int, float)):'):
-            if not isinstance(self._definition['multipleOf'], (int, float)):
+        with self.l('if isinstance({variable}, (int, float, Decimal)):'):
+            if not isinstance(self._definition['multipleOf'], (int, float, decimal.Decimal)):
                 raise JsonSchemaDefinitionException('multipleOf must be a number')
             # For proper multiplication check of floats we need to use decimals,
             # because for example 19.01 / 0.01 = 1901.0000000000002.
             if isinstance(self._definition['multipleOf'], float):
-                self._extra_imports_lines.append('from decimal import Decimal')
-                self._extra_imports_objects['Decimal'] = decimal.Decimal
                 self.l('quotient = Decimal(repr({variable})) / Decimal(repr({multipleOf}))')
             else:
                 self.l('quotient = {variable} / {multipleOf}')

--- a/fastjsonschema/draft06.py
+++ b/fastjsonschema/draft06.py
@@ -1,3 +1,4 @@
+import decimal
 from .draft04 import CodeGeneratorDraft04, JSON_TYPE_TO_PYTHON_TYPE
 from .exceptions import JsonSchemaDefinitionException
 from .generator import enforce_list
@@ -73,16 +74,16 @@ class CodeGeneratorDraft06(CodeGeneratorDraft04):
             self.exc('{name} must be {}', ' or '.join(types), rule='type')
 
     def generate_exclusive_minimum(self):
-        with self.l('if isinstance({variable}, (int, float)):'):
-            if not isinstance(self._definition['exclusiveMinimum'], (int, float)):
-                raise JsonSchemaDefinitionException('exclusiveMinimum must be an integer or a float')
+        with self.l('if isinstance({variable}, (int, float, Decimal)):'):
+            if not isinstance(self._definition['exclusiveMinimum'], (int, float, decimal.Decimal)):
+                raise JsonSchemaDefinitionException('exclusiveMinimum must be an integer, a float or a decimal')
             with self.l('if {variable} <= {exclusiveMinimum}:'):
                 self.exc('{name} must be bigger than {exclusiveMinimum}', rule='exclusiveMinimum')
 
     def generate_exclusive_maximum(self):
-        with self.l('if isinstance({variable}, (int, float)):'):
-            if not isinstance(self._definition['exclusiveMaximum'], (int, float)):
-                raise JsonSchemaDefinitionException('exclusiveMaximum must be an integer or a float')
+        with self.l('if isinstance({variable}, (int, float, Decimal)):'):
+            if not isinstance(self._definition['exclusiveMaximum'], (int, float, decimal.Decimal)):
+                raise JsonSchemaDefinitionException('exclusiveMaximum must be an integer, a float or a decimal')
             with self.l('if {variable} >= {exclusiveMaximum}:'):
                 self.exc('{name} must be smaller than {exclusiveMaximum}', rule='exclusiveMaximum')
 

--- a/fastjsonschema/generator.py
+++ b/fastjsonschema/generator.py
@@ -1,4 +1,5 @@
 from collections import OrderedDict
+from decimal import Decimal
 import re
 
 from .exceptions import JsonSchemaValueException, JsonSchemaDefinitionException
@@ -36,8 +37,12 @@ class CodeGenerator:
         # Any extra library should be here to be imported only once.
         # Lines are imports to be printed in the file and objects
         # key-value pair to pass to compile function directly.
-        self._extra_imports_lines = []
-        self._extra_imports_objects = {}
+        self._extra_imports_lines = [
+            "from decimal import Decimal",
+        ]
+        self._extra_imports_objects = {
+            "Decimal": Decimal,
+        }
 
         self._variables = set()
         self._indent = 0

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -1,3 +1,5 @@
+import decimal
+
 import pytest
 
 from fastjsonschema import JsonSchemaValueException
@@ -158,6 +160,19 @@ def test_integer_is_not_number(asserter, value):
     0.001,
 ))
 def test_number_allows_float(asserter, value):
+    asserter({
+        'type': 'number',
+    }, value, value)
+
+
+
+@pytest.mark.parametrize('value', (
+    decimal.Decimal('1.0'),
+    decimal.Decimal('0.1'),
+    decimal.Decimal('0.01'),
+    decimal.Decimal('0.001'),
+))
+def test_number_allows_decimal(asserter, value):
     asserter({
         'type': 'number',
     }, value, value)


### PR DESCRIPTION
Hello, I've added support for Decimal in `number` fields

Closes https://github.com/horejsek/python-fastjsonschema/issues/122