### PR TITLE
Lazy import urllib

### DIFF
--- a/fastjsonschema/ref_resolver.py
+++ b/fastjsonschema/ref_resolver.py
@@ -11,7 +11,6 @@ import json
 import re
 from urllib import parse as urlparse
 from urllib.parse import unquote
-from urllib.request import urlopen
 
 from .exceptions import JsonSchemaDefinitionException
 
@@ -59,6 +58,8 @@ def resolve_remote(uri, handlers):
     if scheme in handlers:
         result = handlers[scheme](uri)
     else:
+        from urllib.request import urlopen
+
         req = urlopen(uri)
         encoding = req.info().get_content_charset() or 'utf-8'
         try:

--- a/fastjsonschema/ref_resolver.py
+++ b/fastjsonschema/ref_resolver.py
@@ -7,11 +7,8 @@ Code adapted from https://github.com/Julian/jsonschema
 """
 
 import contextlib
-import json
 import re
 from urllib import parse as urlparse
-from urllib.parse import unquote
-from urllib.request import urlopen
 
 from .exceptions import JsonSchemaDefinitionException
 
@@ -29,6 +26,8 @@ def resolve_path(schema, fragment):
 
     Path is unescaped according https://tools.ietf.org/html/rfc6901
     """
+    from urllib.parse import unquote
+
     fragment = fragment.lstrip('/')
     parts = unquote(fragment).split('/') if fragment else []
     for part in parts:
@@ -55,6 +54,9 @@ def resolve_remote(uri, handlers):
         urllib library is used to fetch requests from the remote ``uri``
         if handlers does notdefine otherwise.
     """
+    import json
+    from urllib.request import urlopen
+
     scheme = urlparse.urlsplit(uri).scheme
     if scheme in handlers:
         result = handlers[scheme](uri)
@@ -149,6 +151,8 @@ class RefResolver:
         """
         Get current scope and return it as a valid function name.
         """
+        from urllib.parse import unquote
+
         name = 'validate_' + unquote(self.resolution_scope).replace('~1', '_').replace('~0', '_').replace('"', '')
         name = re.sub(r'($[^a-zA-Z]|[^a-zA-Z0-9])', '_', name)
         name = name.lower().rstrip('_')

--- a/fastjsonschema/ref_resolver.py
+++ b/fastjsonschema/ref_resolver.py
@@ -7,8 +7,11 @@ Code adapted from https://github.com/Julian/jsonschema
 """
 
 import contextlib
+import json
 import re
 from urllib import parse as urlparse
+from urllib.parse import unquote
+from urllib.request import urlopen
 
 from .exceptions import JsonSchemaDefinitionException
 
@@ -26,8 +29,6 @@ def resolve_path(schema, fragment):
 
     Path is unescaped according https://tools.ietf.org/html/rfc6901
     """
-    from urllib.parse import unquote
-
     fragment = fragment.lstrip('/')
     parts = unquote(fragment).split('/') if fragment else []
     for part in parts:
@@ -54,9 +55,6 @@ def resolve_remote(uri, handlers):
         urllib library is used to fetch requests from the remote ``uri``
         if handlers does notdefine otherwise.
     """
-    import json
-    from urllib.request import urlopen
-
     scheme = urlparse.urlsplit(uri).scheme
     if scheme in handlers:
         result = handlers[scheme](uri)
@@ -151,8 +149,6 @@ class RefResolver:
         """
         Get current scope and return it as a valid function name.
         """
-        from urllib.parse import unquote
-
         name = 'validate_' + unquote(self.resolution_scope).replace('~1', '_').replace('~0', '_').replace('"', '')
         name = re.sub(r'($[^a-zA-Z]|[^a-zA-Z0-9])', '_', name)
         name = name.lower().rstrip('_')


### PR DESCRIPTION
Zdravím. :wave: 

First of all thanks for the great project! I am currently thinking about migrating our Python CLI app from `jsonschema`.
The main issue for us is not really the validation speed, but rather the import speed, since we're reading and validating a single config file at each app invocation.

`fastjsonschema` import time is already great (whooping 60ms faster than `jsonschema`), 
but this little change improves speed by another ~30ms, from 77ms to 45ms with Python 3.10 on my machine.