### PR TITLE
Test on Python 3.12

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,8 @@ jobs:
         python:
         - 3.7  # oldest Python supported by PSF
         - "3.10"
-        - "3.11"  # newest Python that is stable
+        - "3.11"
+        - "3.12"  # newest Python that is stable
         platform:
         - ubuntu-latest
         - macos-latest

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: Implementation :: CPython",
         "License :: OSI Approved :: BSD License",
         "Operating System :: OS Independent",

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py{34,35,36,37,38,39,310,311},lint
+envlist = py{34,35,36,37,38,39,310,311,312},lint
 
 [testenv]
 deps =


### PR DESCRIPTION
The package seems to work with Python 3.12, so this just _declares_ support for it and runs tests on it in CI.