### PR TITLE
Use `warnings.catch_warnings` instead of `pytest.warns(None)` in tests

### DIFF
--- a/tests/test_pattern_properties.py
+++ b/tests/test_pattern_properties.py
@@ -1,3 +1,5 @@
+import warnings
+
 import pytest
 
 
@@ -59,12 +61,11 @@ def test_pattern_with_escape_no_warnings(asserter):
         'bar': {}
     }
 
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
         asserter({
             'type': 'object',
             'patternProperties': {
                 '\\w+': {'type': 'object'}
             }
         }, value, value)
-
-    assert len(record) == 0

--- a/tests/test_string.py
+++ b/tests/test_string.py
@@ -1,3 +1,5 @@
+import warnings
+
 import pytest
 
 from fastjsonschema import JsonSchemaValueException
@@ -74,13 +76,12 @@ def test_pattern_with_space(asserter, pattern):
 
 
 def test_pattern_with_escape_no_warnings(asserter):
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
         asserter({
             'type': 'string',
             'pattern': '\\s'
         }, ' ', ' ')
-
-    assert len(record) == 0
 
 
 exc = JsonSchemaValueException('data must be a valid regex', value='{data}', name='data', definition='{definition}', rule='format')


### PR DESCRIPTION
> To ensure that no warnings are emitted, use:
> ```python
> with warnings.catch_warnings():
>     warnings.simplefilter("error")
>     ...
> ```

https://docs.pytest.org/en/7.0.x/how-to/capture-warnings.html#additional-use-cases-of-warnings-in-tests