### PR TITLE
Fix `not: {}` schemas when given falsy instances.

### DIFF
--- a/fastjsonschema/draft04.py
+++ b/fastjsonschema/draft04.py
@@ -206,13 +206,10 @@ class CodeGeneratorDraft04(CodeGenerator):
         means everything is invalid.
         """
         not_definition = self._definition['not']
-        if not_definition is True:
+        if not_definition is True or not_definition == {}:
             self.exc('{name} must not be there', rule='not')
         elif not_definition is False:
             return
-        elif not not_definition:
-            with self.l('if {}:', self._variable):
-                self.exc('{name} must NOT match a disallowed definition', rule='not')
         else:
             with self.l('try:', optimize=False):
                 self.generate_func_code_block(not_definition, self._variable, self._variable_name)


### PR DESCRIPTION
These were improperly considering objects like None to be valid under that schema.

The fix here simply adds {} as another special cased schema, since presumably the `is True` block is meant as an optimization.

Note that there are of course many other things you can give to `not` which disallow any possible instance, like `not: {"title": "foo"}` but the fallback block should presumably catch them.

The block that was deleted here never looks correct to me (so I've simply deleted it). Running the updated test suite would seem to confirm, as this change takes the suite from:

    321 failed, 3268 passed, 12 deselected, 152 xfailed, 140 xpassed

to

    309 failed, 3280 passed, 12 deselected, 152 xfailed, 140 xpassed

i.e. a strict increase in compliance.

--

In order to put in this fix I updated your copy of the test suite, which seemed quite out of date.

You can also normally see those results on [Bowtie's](https://github.com/bowtie-json-schema/bowtie) [report for the implementation](https://bowtie.report/#/implementations/python-fastjsonschema) though actually this bug was discovered (and additional tests added to the test suite) because Bowtie "smoke tests" implementations when it builds them with some simple schemas to ensure basic correctness -- and these schemas are the ones it uses, which actually were incorrectly failing!, hence the PR.

Doing the test suite upgrade leaves lots of failures for other behavior -- I'm not sure what you typically do for that, whether you mark them as `xfail` until you fix them or whatever.