### PR TITLE
Update ref_resolver.py

### DIFF
--- a/fastjsonschema/ref_resolver.py
+++ b/fastjsonschema/ref_resolver.py
@@ -66,6 +66,8 @@ def resolve_remote(uri, handlers):
             result = json.loads(req.read().decode(encoding),)
         except ValueError as exc:
             raise JsonSchemaDefinitionException('{} failed to decode: {}'.format(uri, exc))
+        finally:
+            req.close()
     return result
 
 


### PR DESCRIPTION
fix: ensure file is closed in resolve_remote function

Added `req.close()` in the `finally` block of the resolve_remote function to properly close the file after use. This prevents ResourceWarning due to unclosed file objects.