### PR TITLE
Test on Python 3.13

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,9 +14,11 @@ jobs:
     strategy:
       matrix:
         python:
+        - "3.9" # oldest Python supported by PSF
         - "3.10"
         - "3.11"
-        - "3.12"  # newest Python that is stable
+        - "3.12"
+        - "3.13"  # newest Python that is stable
         platform:
         - ubuntu-latest
         - macos-latest

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ setup(
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "Programming Language :: Python :: Implementation :: CPython",
         "License :: OSI Approved :: BSD License",
         "Operating System :: OS Independent",

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py{34,35,36,37,38,39,310,311,312},lint
+envlist = py{34,35,36,37,38,39,310,311,312,313},lint
 
 [testenv]
 deps =


### PR DESCRIPTION
Python 3.13 was released on 2024-10-07. This package already supports it, so this only adds the packaging metadata and adds it to the test matrix to prevent regressions.