### PR TITLE
Fix date pattern regexp

### DIFF
--- a/fastjsonschema/draft07.py
+++ b/fastjsonschema/draft07.py
@@ -3,7 +3,7 @@ from .draft06 import CodeGeneratorDraft06
 
 class CodeGeneratorDraft07(CodeGeneratorDraft06):
     FORMAT_REGEXS = dict(CodeGeneratorDraft06.FORMAT_REGEXS, **{
-        'date': r'^(?P<year>\d{4})-(?P<month>(0[1-9]|1[1-2]))-(?P<day>(0[1-9]|[12]\d|3[01]))\Z',
+        'date': r'^(?P<year>\d{4})-(?P<month>(0[1-9]|1[0-2]))-(?P<day>(0[1-9]|[12]\d|3[01]))\Z',
         'iri': r'^\w+:(\/?\/?)[^\s]+\Z',
         'iri-reference': r'^(\w+:(\/?\/?))?[^#\\\s]*(#[^\\\s]*)?\Z',
         'idn-email': r'^[^@]+@[^@]+\.[^@]+\Z',

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -43,6 +43,7 @@ exc = JsonSchemaValueException('data must be date', value='{data}', name='data',
     ('bla', exc),
     ('2018-2-5', exc),
     ('2018-02-05', '2018-02-05'),
+    ('2018-10-31', '2018-10-31'),
 ])
 def test_date(asserter, value, expected):
     asserter({


### PR DESCRIPTION
Version 2.21.0 introduced a bug causing all strings with format date to fail if the date is in October. This PR fixes the changed regular expression.