### PR TITLE
Note and test support for Python 3.14

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,11 +14,11 @@ jobs:
     strategy:
       matrix:
         python:
-        - "3.9" # oldest Python supported by PSF
-        - "3.10"
+        - "3.10" # oldest Python supported by PSF
         - "3.11"
         - "3.12"
-        - "3.13"  # newest Python that is stable
+        - "3.13"
+        - "3.14"  # newest Python that is stable
         platform:
         - ubuntu-latest
         - macos-latest

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ setup(
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
         "Programming Language :: Python :: Implementation :: CPython",
         "License :: OSI Approved :: BSD License",
         "Operating System :: OS Independent",


### PR DESCRIPTION
Thank you for this great library!
Python 3.9 fell out of support [a couple of days ago](https://www.python.org/downloads/) so I updated that too.
Would you rather keep it for now?