### PR TITLE
Fix IndentationError when a subschema generates no validation code

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -5,7 +5,7 @@
 * Fixed comparing values for enum and const validations
 * Fixed resolving plain-name ref fragments
 * Fixed not throwing when unknown format is used
-* Fixed compilation of if/then/else and propertyNames when if schema generates no validation code
+* Fixed compilation of not, if/then/else, items, additionalItems, propertyNames and schema dependencies when a subschema generates no validation code
 * Added option to get all the errors (set `fast_fail` to `False`)
 * Added basic type hints
 * Added support of duration and uuid formats from draft-2019

--- a/fastjsonschema/draft04.py
+++ b/fastjsonschema/draft04.py
@@ -256,7 +256,10 @@ class CodeGeneratorDraft04(CodeGenerator):
             self.exc('{name} must NOT match a disallowed definition', rule='not')
         else:
             with self.l('try:', optimize=False):
+                code_len = len(self._code)
                 self.generate_func_code_block(not_definition, self._variable, self._variable_name)
+                if len(self._code) == code_len:
+                    self.l('pass')
             self.l('except JsonSchemaValueException: pass')
             with self.l('else:'):
                 self.exc('{name} must NOT match a disallowed definition', rule='not')
@@ -464,22 +467,24 @@ class CodeGeneratorDraft04(CodeGenerator):
                             self.exc('{name} must contain only specified items', rule='items')
                     else:
                         with self.l('for {variable}_x, {variable}_item in enumerate({variable}[{0}:], {0}):', len(items_definition)):
-                            count = self.generate_func_code_block(
+                            code_len = len(self._code)
+                            self.generate_func_code_block(
                                 self._definition['additionalItems'],
                                 '{}_item'.format(self._variable),
                                 '{}[{{{}_x}}]'.format(self._variable_name, self._variable),
                             )
-                            if not count:
+                            if len(self._code) == code_len:
                                 self.l('pass')
             else:
                 if items_definition:
                     with self.l('for {variable}_x, {variable}_item in enumerate({variable}):'):
-                        count = self.generate_func_code_block(
+                        code_len = len(self._code)
+                        self.generate_func_code_block(
                             items_definition,
                             '{}_item'.format(self._variable),
                             '{}[{{{}_x}}]'.format(self._variable_name, self._variable),
                         )
-                        if not count:
+                        if len(self._code) == code_len:
                             self.l('pass')
 
     def generate_min_properties(self):
@@ -658,6 +663,9 @@ class CodeGeneratorDraft04(CodeGenerator):
                             with self.l('if "{}" not in {variable}:', self.e(value)):
                                 self.exc('{name} missing dependency {} for {}', self.e(value), self.e(key), rule='dependencies')
                     else:
+                        code_len = len(self._code)
                         self.generate_func_code_block(values, self._variable, self._variable_name, clear_variables=True)
+                        if len(self._code) == code_len:
+                            self.l('pass')
             if is_empty:
                 self.l('pass')

--- a/fastjsonschema/draft06.py
+++ b/fastjsonschema/draft06.py
@@ -126,13 +126,14 @@ class CodeGeneratorDraft06(CodeGeneratorDraft04):
                     self.l('{variable}_property_names = True')
                     with self.l('for {variable}_key in {variable}:'):
                         with self.l('try:'):
-                            count = self.generate_func_code_block(
+                            code_len = len(self._code)
+                            self.generate_func_code_block(
                                 property_names_definition,
                                 '{}_key'.format(self._variable),
                                 self._variable_name,
                                 clear_variables=True,
                             )
-                            if not count:
+                            if len(self._code) == code_len:
                                 self.l('pass')
                         with self.l('except JsonSchemaValueException:'):
                             self.l('{variable}_property_names = False')

--- a/fastjsonschema/draft07.py
+++ b/fastjsonschema/draft07.py
@@ -68,22 +68,28 @@ class CodeGeneratorDraft07(CodeGeneratorDraft06):
                 self.l('pass')
         with self.l('except JsonSchemaValueException:'):
             if 'else' in self._definition:
+                code_len = len(self._code)
                 self.generate_func_code_block(
                     self._definition['else'],
                     self._variable,
                     self._variable_name,
                     clear_variables=True
                 )
+                if len(self._code) == code_len:
+                    self.l('pass')
             else:
                 self.l('pass')
         if 'then' in self._definition:
             with self.l('else:'):
+                code_len = len(self._code)
                 self.generate_func_code_block(
                     self._definition['then'],
                     self._variable,
                     self._variable_name,
                     clear_variables=True
                 )
+                if len(self._code) == code_len:
+                    self.l('pass')
 
     def generate_content_encoding(self):
         """

--- a/tests/test_array.py
+++ b/tests/test_array.py
@@ -207,3 +207,14 @@ def test_issue_114(asserter):
     value = {"a": []}
     expected = value
     asserter(schema, value, expected)
+
+
+def test_items_subschema_without_validation_code(asserter):
+    asserter({'items': {'not': False}}, [1, 2], [1, 2])
+
+
+def test_additional_items_subschema_without_validation_code(asserter):
+    asserter({
+        'items': [{'type': 'string'}],
+        'additionalItems': {'format': 'unknown-format'},
+    }, ['a', 1], ['a', 1])

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -99,3 +99,35 @@ def test_one_of_factorized(asserter, value, expected):
 ])
 def test_not(asserter, value, expected):
     asserter({'not': {'type': 'number'}}, value, expected)
+
+
+exc = JsonSchemaValueException('data must NOT match a disallowed definition', value='{data}', name='data', definition='{definition}', rule='not')
+@pytest.mark.parametrize('subdefinition', [
+    {'title': 'x'},
+    {'description': 'd'},
+    {'$comment': 'c'},
+    {'examples': [1]},
+    {'default': 5},
+    {'readOnly': True},
+    {'not': False},
+    {'format': 'unknown-format'},
+    {'uniqueItems': False},
+])
+@pytest.mark.parametrize('value', [0, 'abc', {}])
+def test_not_subschema_without_validation_code(asserter, subdefinition, value):
+    """Subschema generating no validation code matches everything, so not must reject everything."""
+    asserter({'not': subdefinition}, value, exc)
+
+
+@pytest.mark.parametrize('schema_version', [
+    'http://json-schema.org/draft-04/schema',
+    'http://json-schema.org/draft-06/schema',
+    'http://json-schema.org/draft-07/schema',
+    'https://json-schema.org/draft/2019-09/schema',
+])
+def test_not_annotation_only_all_drafts(asserter, schema_version):
+    asserter({'$schema': schema_version, 'not': {'title': 'x'}}, 1, exc)
+
+
+def test_not_not_annotation_only(asserter):
+    asserter({'not': {'not': {'title': 'x'}}}, 1, 1)

--- a/tests/test_composition.py
+++ b/tests/test_composition.py
@@ -140,3 +140,31 @@ def test_if_then_empty_if():
         "version": "2.0",
         "terminal": "t1",
     }
+
+
+def test_if_then_else_annotation_only_then():
+    schema = {
+        "$schema": "http://json-schema.org/draft-07/schema",
+        "if": {"type": "string"},
+        "then": {"title": "x"},
+        "else": {"type": "integer"},
+    }
+    validator = fastjsonschema.compile(schema)
+    assert validator("abc") == "abc"
+    assert validator(42) == 42
+    with pytest.raises(JsonSchemaValueException):
+        validator(4.5)
+
+
+def test_if_then_else_annotation_only_else():
+    schema = {
+        "$schema": "http://json-schema.org/draft-07/schema",
+        "if": {"type": "string"},
+        "then": {"minLength": 2},
+        "else": {"title": "x"},
+    }
+    validator = fastjsonschema.compile(schema)
+    assert validator("abc") == "abc"
+    assert validator(42) == 42
+    with pytest.raises(JsonSchemaValueException):
+        validator("a")

--- a/tests/test_object.py
+++ b/tests/test_object.py
@@ -300,3 +300,19 @@ def test_property_names_description_only():
     compile(code, '<string>', 'exec')
     validator = fastjsonschema.compile(schema)
     assert validator({'build': {}, 'test': 1}) == {'build': {}, 'test': 1}
+
+
+def test_property_names_subschema_without_validation_code():
+    schema = {
+        'type': 'object',
+        'propertyNames': {'not': False},
+    }
+    validator = fastjsonschema.compile(schema)
+    assert validator({'build': {}, 'test': 1}) == {'build': {}, 'test': 1}
+
+
+def test_dependencies_annotation_only_schema():
+    schema = {'dependencies': {'foo': {'title': 'x'}}}
+    validator = fastjsonschema.compile(schema)
+    assert validator({'foo': 1}) == {'foo': 1}
+    assert validator({'bar': 1}) == {'bar': 1}


### PR DESCRIPTION
`compile()` generates invalid Python for some valid schemas:

```python
>>> fastjsonschema.compile({"not": {"title": "x"}})
IndentationError: expected an indented block after 'try' statement on line 4
```

Any truthy subschema that produces no validation code triggers this: annotation-only schemas (`title`, `description`, `$comment`, ...), unknown keywords, or no-op keywords such as `{"not": false}`, `{"uniqueItems": false}`, or an unrecognized `format` (a no-op since 63e29e3). The generator emits a block header with nothing under it.

This is the same class as #204/#205, so I probed every subschema position of every generator with code-less subschemas across drafts 04/06/07/2019. Seven sites are affected:

- `not` (try body) — unguarded
- `then` and `else` of if-then-else — 263ecad guarded only the `if` block
- schema-form `dependencies` — unguarded
- single-schema `items`, `additionalItems`, `propertyNames` — guarded, but by the number of keyword functions run (the return value of `generate_func_code_block`), which misses keywords that run and emit nothing: `{"items": {"not": false}}` still crashed

The fix applies the `code_len` snapshot pattern from 263ecad at all seven sites, replacing the count-based guards. The remaining generators (anyOf/oneOf/contains/properties/patternProperties/additionalProperties) always emit at least one body line and were verified unaffected.

This also fixes the compile crash on the suite's `optional/unknownKeyword.json` — three of its cases now pass, but the file has to stay in `ignored_suite_files` because its other cases need `$ref`-to-embedded-`$id` resolution, which is a separate gap.

Independent of #181, which fixes a different `generate_not` bug (`not: {}` accepting falsy instances); the two compose.
