### PR TITLE
fix: don't leak variables from not blocks into the outer scope

### DIFF
--- a/fastjsonschema/draft04.py
+++ b/fastjsonschema/draft04.py
@@ -256,7 +256,7 @@ class CodeGeneratorDraft04(CodeGenerator):
             self.exc('{name} must NOT match a disallowed definition', rule='not')
         else:
             with self.l('try:', optimize=False):
-                self.generate_func_code_block(not_definition, self._variable, self._variable_name)
+                self.generate_func_code_block(not_definition, self._variable, self._variable_name, clear_variables=True)
             self.l('except JsonSchemaValueException: pass')
             with self.l('else:'):
                 self.exc('{name} must NOT match a disallowed definition', rule='not')

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -99,3 +99,19 @@ def test_one_of_factorized(asserter, value, expected):
 ])
 def test_not(asserter, value, expected):
     asserter({'not': {'type': 'number'}}, value, expected)
+
+
+@pytest.mark.parametrize('value, expected', [
+    ({'a': 1}, {'a': 1}),
+    ({'b': 2}, {'b': 2}),
+    ({'a': 1, 'b': 2}, JsonSchemaValueException('data must NOT match a disallowed definition', value='{data}', name='data', definition='{definition}', rule='not')),
+])
+def test_not_with_object_and_additional_properties(asserter, value, expected):
+    # Regression test: variables created inside the not block must not leak
+    # into the outer scope (issue #208).
+    asserter({
+        'type': 'object',
+        'properties': {'a': {}, 'b': {}},
+        'additionalProperties': False,
+        'not': {'properties': {'a': {}, 'b': {}}, 'required': ['a', 'b']},
+    }, value, expected)


### PR DESCRIPTION
This is a proposed fix for top level not generating invalid Python code. Turned out to be a one-line fix.

Fixes #208

:robot:

Assisted-by: ClaudeCode:claude-fable-5
